### PR TITLE
feat: auto-refresh dashboard when tabs change

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -1477,6 +1477,44 @@ document.addEventListener('input', async (e) => {
 
 
 /* ----------------------------------------------------------------
+   LIVE TAB LISTENERS — re-render when tabs change
+   Debounced so rapid tab changes don't cause excessive re-renders.
+   ---------------------------------------------------------------- */
+let _tabRefreshTimer = null;
+let _initialRenderDone = false;
+
+function scheduleRefresh() {
+  if (_tabRefreshTimer) clearTimeout(_tabRefreshTimer);
+  _tabRefreshTimer = setTimeout(() => {
+    // Skip entrance animations on subsequent renders to prevent flickering
+    if (_initialRenderDone) {
+      document.body.classList.add('no-entrance-anim');
+    }
+    renderDashboard();
+  }, 300);
+}
+
+if (typeof chrome !== 'undefined' && chrome.tabs) {
+  chrome.tabs.onCreated.addListener(scheduleRefresh);
+  chrome.tabs.onRemoved.addListener(scheduleRefresh);
+  chrome.tabs.onUpdated.addListener((_tabId, changeInfo) => {
+    // Only refresh when the tab finishes loading or the URL changes
+    if (changeInfo.status === 'complete' || changeInfo.url) {
+      scheduleRefresh();
+    }
+  });
+  // Only refresh when switching BACK to Tab Out, not on every tab switch
+  chrome.tabs.onActivated.addListener(async (activeInfo) => {
+    try {
+      const tab = await chrome.tabs.get(activeInfo.tabId);
+      if (tab.url && tab.url.startsWith(`chrome-extension://${chrome.runtime.id}/`)) {
+        scheduleRefresh();
+      }
+    } catch { /* tab may have been closed before we could query it */ }
+  });
+}
+
+/* ----------------------------------------------------------------
    INITIALIZE
    ---------------------------------------------------------------- */
-renderDashboard();
+renderDashboard().then(() => { _initialRenderDone = true; });

--- a/extension/style.css
+++ b/extension/style.css
@@ -671,6 +671,20 @@ header { animation: fadeUp 0.5s ease both; }
 .abandoned-section .missions .mission-card:nth-child(3) { animation: fadeUp 0.4s ease 0.6s both; }
 footer { animation: fadeUp 0.5s ease 0.65s both; }
 
+/* Disable entrance animations on live-refresh to prevent flickering */
+body.no-entrance-anim header,
+body.no-entrance-anim .tab-cleanup-banner,
+body.no-entrance-anim .nudge-banner,
+body.no-entrance-anim .active-section .section-header,
+body.no-entrance-anim .active-section .missions .mission-card,
+body.no-entrance-anim .abandoned-section .section-header,
+body.no-entrance-anim .abandoned-section .missions .mission-card,
+body.no-entrance-anim footer,
+body.no-entrance-anim .deferred-list .deferred-item,
+body.no-entrance-anim .deferred-column .section-header {
+  animation: none !important;
+}
+
 .deferred-list .deferred-item:nth-child(1) { animation-delay: 0.05s; }
 .deferred-list .deferred-item:nth-child(2) { animation-delay: 0.1s; }
 .deferred-list .deferred-item:nth-child(3) { animation-delay: 0.15s; }


### PR DESCRIPTION
## Summary

- Dashboard now re-renders automatically when tabs are opened, closed, or updated — no manual reload needed
- Uses `chrome.tabs` event listeners (`onCreated`, `onRemoved`, `onUpdated`, `onActivated`) with a 300ms debounce to avoid excessive re-renders
- `onActivated` only triggers when switching back to the Tab Out page, not on every tab switch
- `onUpdated` filters to `status === 'complete'` or URL changes, ignoring noisy intermediate events
- Entrance animations preserved on initial page load but disabled on live-refresh to prevent card flickering

## Changes

- `extension/app.js` — added tab event listeners + debounced `scheduleRefresh()` + `_initialRenderDone` flag
- `extension/style.css` — added `body.no-entrance-anim` rule to suppress CSS animations on re-render

## Test plan

- [ ] Open Tab Out (new tab), verify entrance animations play normally
- [ ] Open/close other tabs, verify Tab Out dashboard updates in real time without flickering
- [ ] Rapidly open multiple tabs, verify no excessive re-renders (debounce working)
- [ ] Switch between tabs, verify refresh only fires when switching back to Tab Out page

🤖 Generated with [Claude Code](https://claude.com/claude-code)