### PR TITLE
feat: add dark mode following system preference

### DIFF
--- a/extension/style.css
+++ b/extension/style.css
@@ -18,6 +18,7 @@
   --status-abandoned: #b35a5a;
   --card-bg: #fffdf9;
   --shadow: rgba(26, 22, 19, 0.06);
+  color-scheme: light dark;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -35,6 +36,7 @@
     --status-abandoned: #c46a6a;
     --card-bg: #211e1b;
     --shadow: rgba(0, 0, 0, 0.3);
+    color-scheme: dark;
   }
 }
 
@@ -101,8 +103,8 @@ header {
 
 /* ---- Tab cleanup banner ---- */
 .tab-cleanup-banner {
-  background: linear-gradient(135deg, rgba(200, 113, 58, 0.04), rgba(200, 113, 58, 0.09));
-  border: 1px solid rgba(200, 113, 58, 0.18);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent-amber) 4%, transparent), color-mix(in srgb, var(--accent-amber) 9%, transparent));
+  border: 1px solid color-mix(in srgb, var(--accent-amber) 18%, transparent);
   border-radius: 8px;
   padding: 16px 24px;
   display: flex;
@@ -121,7 +123,7 @@ header {
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background: rgba(200, 113, 58, 0.1);
+  background: color-mix(in srgb, var(--accent-amber) 10%, transparent);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -165,8 +167,8 @@ header {
 
 /* ---- Nudge banner ---- */
 .nudge-banner {
-  background: linear-gradient(135deg, rgba(179, 90, 90, 0.04), rgba(179, 90, 90, 0.08));
-  border: 1px solid rgba(179, 90, 90, 0.15);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent-rose) 4%, transparent), color-mix(in srgb, var(--accent-rose) 8%, transparent));
+  border: 1px solid color-mix(in srgb, var(--accent-rose) 15%, transparent);
   border-radius: 8px;
   padding: 16px 24px;
   display: flex;
@@ -179,7 +181,7 @@ header {
   width: 36px;
   height: 36px;
   border-radius: 50%;
-  background: rgba(179, 90, 90, 0.1);
+  background: color-mix(in srgb, var(--accent-rose) 10%, transparent);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -329,17 +331,17 @@ header {
 
 .mission-tag.active {
   color: var(--status-active);
-  background: rgba(61, 122, 74, 0.08);
+  background: color-mix(in srgb, var(--status-active) 8%, transparent);
 }
 
 .mission-tag.cooling {
   color: var(--status-cooling);
-  background: rgba(184, 137, 46, 0.08);
+  background: color-mix(in srgb, var(--status-cooling) 8%, transparent);
 }
 
 .mission-tag.abandoned {
   color: var(--status-abandoned);
-  background: rgba(179, 90, 90, 0.08);
+  background: color-mix(in srgb, var(--status-abandoned) 8%, transparent);
 }
 
 /* Tab indicator badge — shows how many Chrome tabs are still open for this mission */
@@ -350,7 +352,7 @@ header {
   font-size: 10px;
   font-weight: 500;
   color: var(--accent-amber);
-  background: rgba(200, 113, 58, 0.08);
+  background: color-mix(in srgb, var(--accent-amber) 8%, transparent);
   padding: 2px 8px;
   border-radius: 3px;
 }
@@ -381,7 +383,7 @@ header {
   padding: 8px 4px;
   border-radius: 0;
   border: none;
-  border-bottom: 1px solid rgba(154, 145, 138, 0.1);
+  border-bottom: 1px solid color-mix(in srgb, var(--muted) 10%, transparent);
   position: relative;
   display: flex;
   align-items: center;
@@ -421,7 +423,7 @@ header {
 
 /* Duplicate border highlight */
 .chip-has-dupes {
-  border-color: rgba(200, 113, 58, 0.25);
+  border-color: color-mix(in srgb, var(--accent-amber) 25%, transparent);
 }
 
 /* Action buttons grouped on the right */
@@ -456,17 +458,17 @@ header {
 
 .chip-action:hover {
   opacity: 1;
-  background: rgba(154, 145, 138, 0.1);
+  background: color-mix(in srgb, var(--muted) 10%, transparent);
 }
 
 .chip-save:hover {
   color: var(--accent-sage);
-  background: rgba(90, 122, 98, 0.08);
+  background: color-mix(in srgb, var(--accent-sage) 8%, transparent);
 }
 
 .chip-close:hover {
   color: var(--status-abandoned);
-  background: rgba(179, 90, 90, 0.08);
+  background: color-mix(in srgb, var(--status-abandoned) 8%, transparent);
 }
 
 .page-chip.clickable {
@@ -475,7 +477,7 @@ header {
 }
 
 .page-chip.clickable:hover {
-  background: rgba(200, 113, 58, 0.04);
+  background: color-mix(in srgb, var(--accent-amber) 4%, transparent);
 }
 
 /* "+N more" overflow chip */
@@ -552,24 +554,24 @@ header {
 }
 
 .action-btn.close-tabs {
-  border-color: rgba(200, 113, 58, 0.3);
+  border-color: color-mix(in srgb, var(--accent-amber) 30%, transparent);
   color: var(--accent-amber);
-  background: rgba(200, 113, 58, 0.04);
+  background: color-mix(in srgb, var(--accent-amber) 4%, transparent);
 }
 
 .action-btn.close-tabs:hover {
-  background: rgba(200, 113, 58, 0.1);
+  background: color-mix(in srgb, var(--accent-amber) 10%, transparent);
   border-color: var(--accent-amber);
 }
 
 .action-btn.save-tabs {
-  border-color: rgba(90, 122, 98, 0.3);
+  border-color: color-mix(in srgb, var(--accent-sage) 30%, transparent);
   color: var(--accent-sage);
-  background: rgba(90, 122, 98, 0.04);
+  background: color-mix(in srgb, var(--accent-sage) 4%, transparent);
 }
 
 .action-btn.save-tabs:hover {
-  background: rgba(90, 122, 98, 0.1);
+  background: color-mix(in srgb, var(--accent-sage) 10%, transparent);
   border-color: var(--accent-sage);
 }
 
@@ -709,7 +711,7 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 /* ---- "Domain" tag on static domain cards ---- */
 .mission-tag.neutral {
   color: var(--muted);
-  background: rgba(154, 145, 138, 0.1);
+  background: color-mix(in srgb, var(--muted) 10%, transparent);
 }
 
 /* ================================================================
@@ -739,12 +741,12 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   width: 56px;
   height: 56px;
   border-radius: 50%;
-  background: rgba(90, 122, 98, 0.1);
-  border: 1.5px solid rgba(90, 122, 98, 0.3);
+  background: color-mix(in srgb, var(--accent-sage) 10%, transparent);
+  border: 1.5px solid color-mix(in srgb, var(--accent-sage) 30%, transparent);
 
   /* Soft sage glow */
-  box-shadow: 0 0 0 8px rgba(90, 122, 98, 0.05),
-              0 0 0 16px rgba(90, 122, 98, 0.03);
+  box-shadow: 0 0 0 8px color-mix(in srgb, var(--accent-sage) 5%, transparent),
+              0 0 0 16px color-mix(in srgb, var(--accent-sage) 3%, transparent);
 
   display: flex;
   align-items: center;
@@ -799,8 +801,8 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   gap: 12px;
 
   /* Sage green tint — matches accent-sage but very light */
-  background: linear-gradient(135deg, rgba(90, 122, 98, 0.05), rgba(90, 122, 98, 0.10));
-  border: 1px solid rgba(90, 122, 98, 0.22);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--accent-sage) 5%, transparent), color-mix(in srgb, var(--accent-sage) 10%, transparent));
+  border: 1px solid color-mix(in srgb, var(--accent-sage) 22%, transparent);
   border-radius: 8px;
   padding: 10px 16px;
 
@@ -892,7 +894,7 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 }
 
 .update-banner-dismiss:hover {
-  background: rgba(26, 22, 19, 0.06);
+  background: color-mix(in srgb, var(--ink) 6%, transparent);
   color: var(--ink);
 }
 
@@ -946,7 +948,7 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   align-items: flex-start;
   gap: 10px;
   padding: 10px 0;
-  border-bottom: 1px solid rgba(154, 145, 138, 0.12);
+  border-bottom: 1px solid color-mix(in srgb, var(--muted) 12%, transparent);
   animation: fadeUp 0.3s ease both;
 }
 
@@ -1145,7 +1147,7 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   align-items: center;
   gap: 8px;
   padding: 6px 0;
-  border-bottom: 1px solid rgba(154, 145, 138, 0.08);
+  border-bottom: 1px solid color-mix(in srgb, var(--muted) 8%, transparent);
 }
 
 .archive-item:last-child {

--- a/extension/style.css
+++ b/extension/style.css
@@ -20,6 +20,24 @@
   --shadow: rgba(26, 22, 19, 0.06);
 }
 
+@media (prefers-color-scheme: dark) {
+  :root {
+    --ink: #e8e2da;
+    --paper: #1a1713;
+    --warm-gray: #2d2825;
+    --muted: #6b6460;
+    --accent-amber: #d4855a;
+    --accent-sage: #6a9172;
+    --accent-slate: #6a7d8e;
+    --accent-rose: #c46a6a;
+    --status-active: #4e9960;
+    --status-cooling: #c99a3a;
+    --status-abandoned: #c46a6a;
+    --card-bg: #211e1b;
+    --shadow: rgba(0, 0, 0, 0.3);
+  }
+}
+
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {


### PR DESCRIPTION
## Summary

- Add `@media (prefers-color-scheme: dark)` block in `style.css` that overrides all CSS custom properties for dark mode
- Dark mode automatically follows the system preference — no JavaScript or toggle needed
- Color palette keeps the same warm-neutral character: deep brown-black background (`#1a1713`), off-white ink (`#e8e2da`), with slightly brightened accent and status colors for legibility on dark backgrounds

## Test plan

- [ ] Toggle system appearance (macOS: System Settings → Appearance → Dark) and verify the extension new tab page switches to dark mode automatically
- [ ] Verify all text is readable in both modes
- [ ] Verify accent/status colors (amber, sage, rose) are visible in dark mode