### PR TITLE
feat: add search bar to filter open tabs

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -1445,6 +1445,53 @@ document.addEventListener('click', (e) => {
   }
 });
 
+// ---- Open tabs search — filter domain cards as user types ----
+document.addEventListener('input', (e) => {
+  if (e.target.id !== 'openTabsSearch') return;
+
+  const q = e.target.value.trim().toLowerCase();
+  const missionsEl = document.getElementById('openTabsMissions');
+  if (!missionsEl) return;
+
+  const cards = missionsEl.querySelectorAll('.mission-card');
+
+  if (q.length === 0) {
+    // Reset — remove all search classes and restore overflow state
+    missionsEl.classList.remove('is-searching');
+    cards.forEach(card => {
+      card.classList.remove('search-hidden');
+      card.querySelectorAll('.page-chip').forEach(chip => chip.classList.remove('search-hidden'));
+    });
+    return;
+  }
+
+  missionsEl.classList.add('is-searching');
+
+  cards.forEach(card => {
+    const domainLabel = (card.querySelector('.mission-name')?.textContent || '').toLowerCase();
+    // If the domain/group name itself matches, show all chips in this card
+    if (domainLabel.includes(q)) {
+      card.classList.remove('search-hidden');
+      card.querySelectorAll('.page-chip:not(.page-chip-overflow)').forEach(chip => chip.classList.remove('search-hidden'));
+      return;
+    }
+
+    let anyVisible = false;
+    card.querySelectorAll('.page-chip:not(.page-chip-overflow)').forEach(chip => {
+      const title = (chip.title || chip.querySelector('.chip-text')?.textContent || '').toLowerCase();
+      const url   = (chip.dataset.tabUrl || '').toLowerCase();
+      if (title.includes(q) || url.includes(q)) {
+        chip.classList.remove('search-hidden');
+        anyVisible = true;
+      } else {
+        chip.classList.add('search-hidden');
+      }
+    });
+
+    card.classList.toggle('search-hidden', !anyVisible);
+  });
+});
+
 // ---- Archive search — filter archived items as user types ----
 document.addEventListener('input', async (e) => {
   if (e.target.id !== 'archiveSearch') return;
@@ -1472,6 +1519,33 @@ document.addEventListener('input', async (e) => {
       || '<div style="font-size:12px;color:var(--muted);padding:8px 0">No results</div>';
   } catch (err) {
     console.warn('[tab-out] Archive search failed:', err);
+  }
+});
+
+
+/* ----------------------------------------------------------------
+   KEYBOARD SHORTCUTS
+   ---------------------------------------------------------------- */
+
+document.addEventListener('keydown', (e) => {
+  const search = document.getElementById('openTabsSearch');
+  if (!search) return;
+
+  // '/' — focus the search bar (when not already typing in an input)
+  if (e.key === '/' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    const tag = document.activeElement?.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+    e.preventDefault();
+    search.focus();
+    search.select();
+    return;
+  }
+
+  // Escape — clear and blur search
+  if (e.key === 'Escape' && document.activeElement === search) {
+    search.value = '';
+    search.dispatchEvent(new Event('input'));
+    search.blur();
   }
 });
 

--- a/extension/index.html
+++ b/extension/index.html
@@ -59,6 +59,11 @@
       <div class="section-header">
         <h2 id="openTabsSectionTitle">Right now</h2>
         <div class="section-line"></div>
+        <div class="open-tabs-search-wrap">
+          <svg class="search-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" /></svg>
+          <input type="text" class="open-tabs-search" id="openTabsSearch" placeholder="Search" autocomplete="off" spellcheck="false">
+          <span class="open-tabs-search-hint">/</span>
+        </div>
         <div class="section-count" id="openTabsSectionCount"></div>
       </div>
       <div class="missions" id="openTabsMissions"></div>

--- a/extension/style.css
+++ b/extension/style.css
@@ -1121,6 +1121,94 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   color: var(--muted);
 }
 
+/* ---- Open Tabs Search (inline in section-header) ---- */
+
+/* Pill wrapper — always visible, houses icon + input + hint */
+.open-tabs-search-wrap {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+  padding: 3px 8px;
+  border: 1px solid var(--warm-gray);
+  border-radius: 20px;
+  background: transparent;
+  cursor: text;
+  transition: background 0.2s, border-color 0.2s, box-shadow 0.2s;
+}
+
+.open-tabs-search-wrap:focus-within {
+  background: var(--card-bg);
+  border-color: var(--accent-slate);
+  box-shadow: 0 0 0 3px rgba(90, 107, 122, 0.08);
+}
+
+/* Magnifying glass icon — always shown */
+.search-icon {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  color: var(--muted);
+  transition: color 0.2s;
+}
+.open-tabs-search-wrap:focus-within .search-icon {
+  color: var(--accent-slate);
+}
+
+/* The text input — grows on focus */
+.open-tabs-search {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  width: 80px;
+  border: none;
+  background: transparent;
+  color: var(--ink);
+  outline: none;
+  transition: width 0.2s ease;
+}
+
+.open-tabs-search:focus,
+.open-tabs-search:not(:placeholder-shown) {
+  width: 160px;
+}
+
+.open-tabs-search::placeholder {
+  color: var(--muted);
+}
+
+/* "/" hint badge — always visible, fades when active */
+.open-tabs-search-hint {
+  font-size: 11px;
+  color: var(--muted);
+  background: var(--warm-gray);
+  border-radius: 3px;
+  padding: 1px 5px;
+  flex-shrink: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+}
+
+.open-tabs-search-wrap:focus-within .open-tabs-search-hint,
+.open-tabs-search:not(:placeholder-shown) ~ .open-tabs-search-hint {
+  opacity: 0;
+}
+
+/* When actively filtering: expand overflow chip containers */
+.missions.is-searching .page-chips-overflow {
+  display: contents !important;
+}
+.missions.is-searching .page-chip-overflow {
+  display: none !important;
+}
+
+/* Hide non-matching chips and empty cards */
+.page-chip.search-hidden {
+  display: none !important;
+}
+.mission-card.search-hidden {
+  display: none !important;
+}
+
 /* Archive items are simpler — just title + domain + date */
 .archive-item {
   display: flex;


### PR DESCRIPTION
Adds an inline search pill to the open tabs section header with a magnifying glass icon and "/" keyboard shortcut hint. Typing filters domain cards and individual tab chips in real-time; pressing "/" focuses the input and Escape clears it.