### PR TITLE
Make it work in Dia: clicking the toobar icon opens a fresh Tab Out tab.

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -769,7 +769,7 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
     try { domain = new URL(tab.url).hostname; } catch {}
     const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="">` : ''}
       <span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
@@ -850,7 +850,7 @@ function renderDomainCard(group) {
     try { domain = new URL(tab.url).hostname; } catch {}
     const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="">` : ''}
       <span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
@@ -974,7 +974,7 @@ function renderDeferredItem(item) {
       <input type="checkbox" class="deferred-checkbox" data-action="check-deferred" data-deferred-id="${item.id}">
       <div class="deferred-info">
         <a href="${item.url}" target="_blank" rel="noopener" class="deferred-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
-          <img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px" onerror="this.style.display='none'">${item.title || item.url}
+          <img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px">${item.title || item.url}
         </a>
         <div class="deferred-meta">
           <span>${domain}</span>
@@ -1479,4 +1479,11 @@ document.addEventListener('input', async (e) => {
 /* ----------------------------------------------------------------
    INITIALIZE
    ---------------------------------------------------------------- */
+
+// Hide favicon images that fail to load (e.g. unknown domains).
+// Uses capture phase because 'error' events don't bubble.
+document.addEventListener('error', (e) => {
+  if (e.target.tagName === 'IMG') e.target.style.display = 'none';
+}, true);
+
 renderDashboard();

--- a/extension/background.js
+++ b/extension/background.js
@@ -62,6 +62,20 @@ async function updateBadge() {
 
 // ─── Event listeners ──────────────────────────────────────────────────────────
 
+// Open or focus the Tab Out tab when the toolbar icon is clicked.
+// This is the primary access method in browsers that don't support newtab
+// overrides (e.g. Dia), and a convenient shortcut in Chrome.
+chrome.action.onClicked.addListener(async () => {
+  const tabOutUrl = `chrome-extension://${chrome.runtime.id}/index.html`;
+  const existing = await chrome.tabs.query({ url: tabOutUrl });
+  if (existing.length > 0) {
+    await chrome.tabs.update(existing[0].id, { active: true });
+    await chrome.windows.update(existing[0].windowId, { focused: true });
+  } else {
+    await chrome.tabs.create({ url: tabOutUrl });
+  }
+});
+
 // Update badge when the extension is first installed
 chrome.runtime.onInstalled.addListener(() => {
   updateBadge();

--- a/extension/index.html
+++ b/extension/index.html
@@ -127,7 +127,7 @@
 
 <!-- Personal config (gitignored) — defines LOCAL_LANDING_PAGE_PATTERNS etc. -->
 <!-- If the file doesn't exist, that's fine — app.js uses sensible defaults. -->
-<script src="config.local.js" onerror="/* no personal config, that's fine */"></script>
+<script src="config.local.js"></script>
 
 <!-- Main dashboard logic — loads last so the DOM is ready -->
 <script src="app.js"></script>


### PR DESCRIPTION
# Add toolbar icon shortcut: open or focus Tab Out tab

## What changed

Added a `chrome.action.onClicked` listener in `background.js`. Clicking the toolbar icon now opens Tab Out as a regular browser tab — or focuses the existing one if it's already open.

## Why

Tab Out previously relied solely on `chrome_url_overrides: newtab` to surface its dashboard. Browsers like **Dia** intentionally reserve the new tab for their own UI (LLM chat), so the override has no effect there — the extension simply didn't show up.

This change makes Tab Out accessible in any Chromium-based browser, regardless of whether the new tab override is honored.

## Behavior

| Browser | New tab                          | Toolbar click                   |
| ------- | -------------------------------- | ------------------------------- |
| Chrome  | Opens Tab Out (unchanged)        | Opens/focuses Tab Out tab       |
| Dia     | Opens Dia's LLM chat (untouched) | Opens Tab Out as a pinnable tab |

The recommended Dia workflow: click the toolbar icon once, pin the resulting tab, and use Cmd+R to refresh the tab list whenever you need a current view. Clicking any tab chip in the dashboard still jumps to that tab without navigating away from Tab Out.

## Tests

Tested on macOS with:
- Chrome, Version 147.0.7727.56 (Official Build) (arm64)
- Dia, Version 1.26.0 (78679) Chromium Engine Version 147.0.7727.56