### PR TITLE
feat: add refresh button to header

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -1412,6 +1412,16 @@ document.addEventListener('click', async (e) => {
     return;
   }
 
+  // ---- Refresh dashboard ----
+  if (action === 'refresh') {
+    const btn = document.getElementById('refreshBtn');
+    if (btn) btn.classList.add('spinning');
+    await renderDashboard();
+    if (btn) btn.classList.remove('spinning');
+    showToast('Refreshed');
+    return;
+  }
+
   // ---- Close ALL open tabs ----
   if (action === 'close-all-open-tabs') {
     const allUrls = openTabs

--- a/extension/index.html
+++ b/extension/index.html
@@ -26,6 +26,12 @@
       <!-- "Friday, April 4, 2026" — written by getDateDisplay() in app.js -->
       <div class="date" id="dateDisplay"></div>
     </div>
+    <button class="refresh-btn" id="refreshBtn" data-action="refresh" title="Refresh tab list">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+      </svg>
+      Refresh
+    </button>
   </header>
 
   <!-- ================================================================

--- a/extension/style.css
+++ b/extension/style.css
@@ -643,12 +643,35 @@ footer {
   font-family: 'DM Sans', sans-serif;
   font-size: 11px;
   font-weight: 500;
-  color: var(--accent-amber);
+  color: var(--muted);
   background: none;
   border: none;
   cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: color 0.15s, background 0.15s;
+}
+
+.refresh-btn svg {
+  width: 13px;
+  height: 13px;
+}
+
+.refresh-btn:hover {
+  color: var(--accent-amber);
+  background: rgba(200, 113, 58, 0.07);
+}
+
+.refresh-btn.spinning svg {
+  animation: spin 0.6s linear;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
 }
 
 /* ---- Animations ---- */


### PR DESCRIPTION
Adds a refresh button to the top-right of the header that re-fetches all open tabs and re-renders the dashboard. Includes a spin animation on the icon during refresh and a toast confirmation on completion.

See details in image

<img width="1273" height="204" alt="Screenshot 2026-04-16 at 10 22 27 AM" src="https://github.com/user-attachments/assets/a31e3ad0-d19c-40bd-b74d-7e56db0648f4" />

## Changes

- **`index.html`** — refresh button added to `<header>` (top-right, opposite the greeting) with a circular arrow SVG icon
- **`app.js`** — `refresh` action handler added to the click event delegation block; calls `renderDashboard()` to re-fetch all tabs, then shows a "Refreshed" toast
- **`style.css`** — `.refresh-btn` styles (flex layout, muted color, amber hover highlight) and a `.spinning` keyframe animation that rotates the icon once per refresh