### PR TITLE
feat: add privacy mode for screen sharing

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -1477,6 +1477,186 @@ document.addEventListener('input', async (e) => {
 
 
 /* ----------------------------------------------------------------
+   PRIVACY MODE — hide dashboard content during screen sharing
+
+   Toggle with:
+   - The lock icon button in the header
+   - The Esc key
+   State is persisted in chrome.storage.local so it survives new tabs.
+   ---------------------------------------------------------------- */
+
+// ---- Privacy mode storage ----
+
+const PRIVACY_DEFAULTS = { clock: true, date: true, motto: true, search: true, mottoText: '' };
+
+async function getPrivacyMode() {
+  try {
+    const result = await chrome.storage.local.get('privacyMode');
+    return result.privacyMode === true;
+  } catch {
+    return false;
+  }
+}
+
+async function getPrivacySettings() {
+  try {
+    const result = await chrome.storage.local.get('privacySettings');
+    return { ...PRIVACY_DEFAULTS, ...result.privacySettings };
+  } catch {
+    return { ...PRIVACY_DEFAULTS };
+  }
+}
+
+async function savePrivacySettings(settings) {
+  try { await chrome.storage.local.set({ privacySettings: settings }); } catch {}
+}
+
+async function setPrivacyMode(enabled) {
+  try { await chrome.storage.local.set({ privacyMode: enabled }); } catch {}
+  document.body.classList.toggle('privacy-mode', enabled);
+  if (enabled) { applyPrivacyWidgets(); startPrivacyClock(); } else stopPrivacyClock();
+}
+
+// ---- Apply widget visibility from settings ----
+
+async function applyPrivacyWidgets() {
+  const s = await getPrivacySettings();
+  const timeEl   = document.getElementById('privacyTime');
+  const dateEl   = document.getElementById('privacyDate');
+  const mottoEl  = document.getElementById('privacyMotto');
+  const searchEl = document.getElementById('privacySearch');
+
+  if (timeEl)   timeEl.style.display   = s.clock  ? '' : 'none';
+  if (dateEl)   dateEl.style.display   = s.date   ? '' : 'none';
+  if (searchEl) searchEl.style.display = s.search ? '' : 'none';
+  if (mottoEl) {
+    mottoEl.style.display = s.motto && s.mottoText ? '' : 'none';
+    mottoEl.textContent   = s.mottoText || '';
+  }
+
+  // Sync settings panel checkboxes
+  const ids = { psClock: 'clock', psDate: 'date', psMotto: 'motto', psSearch: 'search' };
+  for (const [elId, key] of Object.entries(ids)) {
+    const cb = document.getElementById(elId);
+    if (cb) cb.checked = s[key];
+  }
+  const mottoInput = document.getElementById('psMottoInput');
+  if (mottoInput) mottoInput.value = s.mottoText || '';
+  const mottoEdit = document.getElementById('psMottoEdit');
+  if (mottoEdit) mottoEdit.style.display = s.motto ? '' : 'none';
+}
+
+// ---- Live clock ----
+let privacyClockInterval = null;
+
+function updatePrivacyClock() {
+  const now = new Date();
+  const timeEl = document.getElementById('privacyTime');
+  const dateEl = document.getElementById('privacyDate');
+  if (timeEl) {
+    timeEl.textContent = now.toLocaleTimeString('en-US', {
+      hour: '2-digit', minute: '2-digit', hour12: false
+    });
+  }
+  if (dateEl) {
+    dateEl.textContent = now.toLocaleDateString('en-US', {
+      weekday: 'long', month: 'long', day: 'numeric'
+    });
+  }
+}
+
+function startPrivacyClock() {
+  updatePrivacyClock();
+  if (!privacyClockInterval) {
+    privacyClockInterval = setInterval(updatePrivacyClock, 1000);
+  }
+}
+
+function stopPrivacyClock() {
+  if (privacyClockInterval) {
+    clearInterval(privacyClockInterval);
+    privacyClockInterval = null;
+  }
+}
+
+// ---- Toggle privacy mode ----
+
+async function togglePrivacyMode() {
+  const current = document.body.classList.contains('privacy-mode');
+  await setPrivacyMode(!current);
+}
+
+document.getElementById('privacyToggle')?.addEventListener('click', togglePrivacyMode);
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    // Don't toggle if user is typing in search or motto input
+    const active = document.activeElement;
+    if (active && (active.id === 'privacySearchInput' || active.id === 'psMottoInput')) {
+      active.blur();
+      return;
+    }
+    e.preventDefault();
+    togglePrivacyMode();
+  }
+});
+
+// ---- Settings panel ----
+
+document.getElementById('privacySettingsBtn')?.addEventListener('click', () => {
+  const panel = document.getElementById('privacySettings');
+  if (panel) panel.style.display = panel.style.display === 'none' ? '' : 'none';
+});
+
+// Close settings when clicking outside
+document.addEventListener('click', (e) => {
+  const panel = document.getElementById('privacySettings');
+  const btn   = document.getElementById('privacySettingsBtn');
+  if (panel && panel.style.display !== 'none' && !panel.contains(e.target) && !btn.contains(e.target)) {
+    panel.style.display = 'none';
+  }
+});
+
+// Settings checkbox changes
+for (const id of ['psClock', 'psDate', 'psMotto', 'psSearch']) {
+  document.getElementById(id)?.addEventListener('change', async () => {
+    const s = await getPrivacySettings();
+    s.clock  = document.getElementById('psClock')?.checked ?? true;
+    s.date   = document.getElementById('psDate')?.checked ?? true;
+    s.motto  = document.getElementById('psMotto')?.checked ?? true;
+    s.search = document.getElementById('psSearch')?.checked ?? true;
+    await savePrivacySettings(s);
+    applyPrivacyWidgets();
+  });
+}
+
+// Motto text input (save on blur or Enter)
+const mottoInput = document.getElementById('psMottoInput');
+if (mottoInput) {
+  const saveMotto = async () => {
+    const s = await getPrivacySettings();
+    s.mottoText = mottoInput.value.trim();
+    await savePrivacySettings(s);
+    applyPrivacyWidgets();
+  };
+  mottoInput.addEventListener('blur', saveMotto);
+  mottoInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') { e.preventDefault(); mottoInput.blur(); } });
+}
+
+// ---- Init ----
+
+async function initPrivacyMode() {
+  const enabled = await getPrivacyMode();
+  if (enabled) {
+    document.body.classList.add('privacy-mode');
+    await applyPrivacyWidgets();
+    startPrivacyClock();
+  }
+}
+
+
+/* ----------------------------------------------------------------
    INITIALIZE
    ---------------------------------------------------------------- */
-renderDashboard();
+// Init privacy mode first to avoid content flash, then render
+initPrivacyMode().then(() => renderDashboard());

--- a/extension/index.html
+++ b/extension/index.html
@@ -26,7 +26,58 @@
       <!-- "Friday, April 4, 2026" — written by getDateDisplay() in app.js -->
       <div class="date" id="dateDisplay"></div>
     </div>
+    <div class="header-right">
+      <button class="privacy-toggle" id="privacyToggle" title="Toggle privacy mode (Esc)">
+        <!-- Lock open icon (shown when privacy mode is OFF) -->
+        <svg class="privacy-icon privacy-icon-off" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5V6.75a4.5 4.5 0 1 1 9 0v3.75M3.75 21.75h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H3.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+        </svg>
+        <!-- Lock closed icon (shown when privacy mode is ON) -->
+        <svg class="privacy-icon privacy-icon-on" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 1 0-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 0 0 2.25-2.25v-6.75a2.25 2.25 0 0 0-2.25-2.25H6.75a2.25 2.25 0 0 0-2.25 2.25v6.75a2.25 2.25 0 0 0 2.25 2.25Z" />
+        </svg>
+      </button>
+    </div>
   </header>
+
+  <!-- Privacy mode screen — only visible when privacy mode is active -->
+  <div class="privacy-screen" id="privacyScreen">
+    <div class="privacy-time" id="privacyTime"></div>
+    <div class="privacy-date" id="privacyDate"></div>
+    <div class="privacy-motto" id="privacyMotto"></div>
+    <form class="privacy-search" id="privacySearch" action="https://www.google.com/search" method="GET">
+      <input type="text" name="q" class="privacy-search-input" id="privacySearchInput" placeholder="Search Google" autocomplete="off">
+    </form>
+    <div class="privacy-hint">Press <kbd>Esc</kbd> to show your tabs</div>
+
+    <!-- Settings gear -->
+    <button class="privacy-settings-btn" id="privacySettingsBtn" title="Customize privacy screen">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="16" height="16">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+      </svg>
+    </button>
+
+    <!-- Settings panel -->
+    <div class="privacy-settings" id="privacySettings" style="display:none">
+      <div class="privacy-settings-title">Customize</div>
+      <label class="privacy-setting-row">
+        <input type="checkbox" id="psClock" checked> Clock
+      </label>
+      <label class="privacy-setting-row">
+        <input type="checkbox" id="psDate" checked> Date
+      </label>
+      <label class="privacy-setting-row">
+        <input type="checkbox" id="psMotto" checked> Custom text
+      </label>
+      <div class="privacy-setting-sub" id="psMottoEdit">
+        <input type="text" id="psMottoInput" class="privacy-setting-input" placeholder="Type your text here...">
+      </div>
+      <label class="privacy-setting-row">
+        <input type="checkbox" id="psSearch" checked> Search box
+      </label>
+    </div>
+  </div>
 
   <!-- ================================================================
        TAB OUT DUPES BANNER — appears when you have extra Tab Out tabs open

--- a/extension/style.css
+++ b/extension/style.css
@@ -1156,3 +1156,230 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   opacity: 0.6;
   flex-shrink: 0;
 }
+
+/* ---- Privacy mode toggle ---- */
+.header-right {
+  display: flex;
+  align-items: center;
+}
+
+.privacy-toggle {
+  background: none;
+  border: 1px solid var(--warm-gray);
+  border-radius: 8px;
+  padding: 6px 8px;
+  cursor: pointer;
+  color: var(--muted);
+  display: flex;
+  align-items: center;
+  transition: color 0.2s, border-color 0.2s, background 0.2s;
+}
+
+.privacy-toggle:hover {
+  color: var(--ink);
+  border-color: var(--ink);
+  background: rgba(26, 22, 19, 0.03);
+}
+
+/* Icon visibility: show lock-open by default, lock-closed when active */
+.privacy-icon-on  { display: none; }
+.privacy-icon-off { display: block; }
+
+body.privacy-mode .privacy-icon-on  { display: block; }
+body.privacy-mode .privacy-icon-off { display: none; }
+body.privacy-mode .privacy-toggle {
+  color: var(--accent-amber);
+  border-color: var(--accent-amber);
+}
+
+/* ---- Privacy mode: hide dashboard content ---- */
+body.privacy-mode .tab-cleanup-banner,
+body.privacy-mode .dashboard-columns,
+body.privacy-mode footer {
+  display: none !important;
+}
+
+body.privacy-mode .container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  max-width: 960px;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+body.privacy-mode header {
+  border-bottom: none;
+  margin-bottom: 0;
+}
+
+body.privacy-mode .header-left {
+  display: none;
+}
+
+body.privacy-mode .privacy-screen {
+  display: flex;
+}
+
+/* ---- Privacy screen ---- */
+.privacy-screen {
+  display: none;
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+  user-select: none;
+  position: relative;
+}
+
+.privacy-time {
+  font-family: 'Newsreader', serif;
+  font-weight: 300;
+  font-size: 96px;
+  letter-spacing: -3px;
+  line-height: 1;
+  color: var(--ink);
+}
+
+.privacy-date {
+  font-family: 'Newsreader', serif;
+  font-size: 28px;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--ink);
+  opacity: 0.45;
+  letter-spacing: 0.5px;
+  margin-top: 16px;
+}
+
+.privacy-motto {
+  font-family: 'Newsreader', serif;
+  font-size: 18px;
+  font-weight: 400;
+  font-style: italic;
+  color: var(--muted);
+  margin-top: 24px;
+  max-width: 480px;
+  text-align: center;
+  line-height: 1.5;
+}
+
+.privacy-motto:empty { display: none; }
+
+/* ---- Privacy search box ---- */
+.privacy-search {
+  margin-top: 32px;
+  width: 100%;
+  max-width: 600px;
+}
+
+.privacy-search-input {
+  width: 100%;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 15px;
+  padding: 12px 20px;
+  border: 1px solid var(--warm-gray);
+  border-radius: 24px;
+  background: var(--card-bg);
+  color: var(--ink);
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.privacy-search-input::placeholder {
+  color: var(--muted);
+}
+
+.privacy-search-input:focus {
+  border-color: var(--accent-amber);
+  box-shadow: 0 0 0 3px rgba(200, 113, 58, 0.1);
+}
+
+/* ---- Privacy hint ---- */
+.privacy-hint {
+  font-size: 12px;
+  color: var(--muted);
+  margin-top: 40px;
+  opacity: 0.5;
+}
+
+.privacy-hint kbd {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 11px;
+  background: var(--warm-gray);
+  border-radius: 4px;
+  padding: 2px 6px;
+}
+
+/* ---- Privacy settings gear + panel ---- */
+.privacy-settings-btn {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  opacity: 0.3;
+  transition: opacity 0.2s;
+  padding: 4px;
+  z-index: 11;
+}
+
+.privacy-settings-btn:hover { opacity: 1; }
+
+.privacy-settings {
+  position: fixed;
+  bottom: 52px;
+  right: 24px;
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray);
+  border-radius: 12px;
+  padding: 16px 20px;
+  box-shadow: 0 4px 20px var(--shadow);
+  width: 220px;
+  z-index: 10;
+}
+
+.privacy-settings-title {
+  font-family: 'Newsreader', serif;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--ink);
+  margin-bottom: 12px;
+}
+
+.privacy-setting-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--ink);
+  padding: 4px 0;
+  cursor: pointer;
+}
+
+.privacy-setting-row input[type="checkbox"] {
+  accent-color: var(--accent-amber);
+}
+
+.privacy-setting-sub {
+  padding: 4px 0 4px 24px;
+}
+
+.privacy-setting-input {
+  width: 100%;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  padding: 6px 10px;
+  border: 1px solid var(--warm-gray);
+  border-radius: 6px;
+  background: var(--paper);
+  color: var(--ink);
+  outline: none;
+}
+
+.privacy-setting-input:focus {
+  border-color: var(--accent-amber);
+}


### PR DESCRIPTION
## Summary

- **Privacy mode** hides all tab/domain cards behind a minimal clock + search screen, ideal for screen sharing or presentations
- Toggle via a lock icon in the header or the `Esc` key
- Customizable widgets (clock, date, custom text, Google search box) with settings persisted in `chrome.storage.local`
- Privacy state survives new tabs so you don't have to re-enable it each time

## Details

### Why
Tab Out displays all open tabs grouped by domain — this is sensitive information during screen sharing, demos, or over-the-shoulder situations. Privacy mode lets you instantly hide everything behind a clean, neutral-looking new tab screen.

### What's included
- **HTML**: lock toggle button, privacy screen overlay (clock, date, motto, search, hint), settings panel with checkboxes
- **JS** (~180 lines): storage helpers, live clock, Esc key handler, settings panel logic, init-before-render to prevent content flash
- **CSS** (~230 lines): privacy screen layout, large serif clock, search input, settings panel, smooth transitions using existing design tokens

### How it works
1. Click the lock icon or press `Esc` → dashboard content is hidden, privacy screen appears
2. Click the gear icon (bottom-right) to choose which widgets to show
3. State is saved in `chrome.storage.local` and restored on every new tab

## Test plan
- [ ] Toggle privacy mode on/off via lock icon
- [ ] Toggle via `Esc` key; verify `Esc` in search input just blurs instead of toggling
- [ ] Verify dashboard content is fully hidden in privacy mode
- [ ] Open settings, toggle each widget checkbox, confirm changes apply immediately
- [ ] Enter custom text, blur/press Enter, verify it persists across new tabs
- [ ] Close and reopen a new tab — privacy mode state should be preserved
- [ ] Disable privacy mode — dashboard renders normally with no visual glitches

🤖 Generated with [Claude Code](https://claude.com/claude-code)