### PR TITLE
feat: Chrome tab group view as primary dashboard with domain toggle

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -1234,7 +1234,7 @@ async function renderDomainView(realTabs) {
  * 1. Chrome groups as cards (with color accent bars)
  * 2. Ungrouped tabs as a lightweight "Not grouped" chip cluster
  */
-async function renderGroupView(viewMode) {
+async function renderGroupView() {
   const openTabsSection      = document.getElementById('openTabsSection');
   const openTabsMissionsEl = document.getElementById('openTabsMissions');
   const openTabsSectionCount = document.getElementById('openTabsSectionCount');
@@ -1453,7 +1453,7 @@ async function renderStaticDashboard() {
 
   // --- Branch on view mode ---
   if (effectiveView === 'group') {
-    await renderGroupView(effectiveView);
+    await renderGroupView();
   } else {
     await renderDomainView(realTabs);
   }
@@ -1475,7 +1475,7 @@ async function renderStaticDashboard() {
     const stored = await loadViewMode();
     const view   = (tabGroupsList.length === 0) ? 'domain' : stored;
     if (view === 'group') {
-      await renderGroupView(view);
+      await renderGroupView();
     } else {
       await renderDomainView(getRealTabs());
     }

--- a/extension/app.js
+++ b/extension/app.js
@@ -26,6 +26,9 @@
 // All open tabs — populated by fetchOpenTabs()
 let openTabs = [];
 
+// Chrome tab groups — populated by fetchTabGroups()
+let tabGroupsList = [];
+
 /**
  * fetchOpenTabs()
  *
@@ -45,6 +48,7 @@ async function fetchOpenTabs() {
       title:    t.title,
       windowId: t.windowId,
       active:   t.active,
+      groupId:  t.groupId,  // -1 = ungrouped, >= 0 = Chrome tab group id
       // Flag Tab Out's own pages so we can detect duplicate new tabs
       isTabOut: t.url === newtabUrl || t.url === 'chrome://newtab/',
     }));
@@ -107,6 +111,74 @@ async function closeTabsExact(urls) {
   const toClose = allTabs.filter(t => urlSet.has(t.url)).map(t => t.id);
   if (toClose.length > 0) await chrome.tabs.remove(toClose);
   await fetchOpenTabs();
+}
+
+/**
+ * closeTabsByIds(ids)
+ *
+ * Closes tabs by their numeric tab ids. Used for closing all tabs
+ * in a Chrome tab group (which are identified by tab id, not URL).
+ */
+async function closeTabsByIds(ids) {
+  if (!ids || ids.length === 0) return;
+  await chrome.tabs.remove(ids);
+  await fetchOpenTabs();
+}
+
+/**
+ * loadViewMode()
+ *
+ * Reads the user's preferred view mode from chrome.storage.local.
+ * Returns 'group' if Chrome tab groups exist, otherwise 'domain'.
+ */
+async function loadViewMode() {
+  const { viewMode } = await chrome.storage.local.get('viewMode');
+  return viewMode || 'group';
+}
+
+/**
+ * saveViewMode(mode)
+ *
+ * Persists the user's preferred view mode to chrome.storage.local.
+ */
+async function saveViewMode(mode) {
+  try { await chrome.storage.local.set({ viewMode: mode }); } catch { /* ignore */ }
+}
+
+/**
+ * fetchTabGroups()
+ *
+ * Reads all Chrome tab groups via the tabGroups API.
+ * Populates the module-level tabGroupsList array.
+ */
+async function fetchTabGroups() {
+  try {
+    const groups = await chrome.tabGroups.query({});
+    tabGroupsList = groups;
+  } catch {
+    // tabGroups API unavailable (permission denied or not supported)
+    tabGroupsList = [];
+  }
+}
+
+/**
+ * detectDuplicateTabs(tabs)
+ *
+ * Analyzes a tab array for duplicate URLs.
+ * Returns { urlCounts, uniqueTabs, hasDupes, totalExtras, dupeUrls }.
+ */
+function detectDuplicateTabs(tabs) {
+  const urlCounts = {};
+  for (const tab of tabs) urlCounts[tab.url] = (urlCounts[tab.url] || 0) + 1;
+  const dupeUrls = Object.entries(urlCounts).filter(([, c]) => c > 1);
+  const hasDupes = dupeUrls.length > 0;
+  const totalExtras = dupeUrls.reduce((s, [, c]) => s + c - 1, 0);
+  const seen = new Set();
+  const uniqueTabs = [];
+  for (const tab of tabs) {
+    if (!seen.has(tab.url)) { seen.add(tab.url); uniqueTabs.push(tab); }
+  }
+  return { urlCounts, uniqueTabs, hasDupes, totalExtras, dupeUrls };
 }
 
 /**
@@ -1008,31 +1080,27 @@ function renderArchiveItem(item) {
    MAIN DASHBOARD RENDERER
    ---------------------------------------------------------------- */
 
+/* Chrome Tab Group color → CSS hex mapping */
+const CHROME_GROUP_COLORS = {
+  grey:   '#5f6368',
+  blue:   '#1a73e8',
+  red:    '#d93025',
+  yellow: '#f9ab00',
+  green:  '#1e8e3e',
+  pink:   '#e91e63',
+  purple: '#9c27b0',
+  cyan:   '#00bcd4',
+};
+
 /**
- * renderStaticDashboard()
+ * renderDomainView(realTabs)
  *
- * The main render function:
- * 1. Paints greeting + date
- * 2. Fetches open tabs via chrome.tabs.query()
- * 3. Groups tabs by domain (with landing pages pulled out to their own group)
- * 4. Renders domain cards
- * 5. Updates footer stats
- * 6. Renders the "Saved for Later" checklist
+ * Groups realTabs by domain and renders domain cards.
+ * Extracted from renderStaticDashboard() so the domain view can be
+ * called as a standalone branch alongside the group view.
  */
-async function renderStaticDashboard() {
-  // --- Header ---
-  const greetingEl = document.getElementById('greeting');
-  const dateEl     = document.getElementById('dateDisplay');
-  if (greetingEl) greetingEl.textContent = getGreeting();
-  if (dateEl)     dateEl.textContent     = getDateDisplay();
-
-  // --- Fetch tabs ---
-  await fetchOpenTabs();
-  const realTabs = getRealTabs();
-
-  // --- Group tabs by domain ---
+async function renderDomainView(realTabs) {
   // Landing pages (Gmail inbox, Twitter home, etc.) get their own special group
-  // so they can be closed together without affecting content tabs on the same domain.
   const LANDING_PAGE_PATTERNS = [
     { hostname: 'mail.google.com', test: (p, h) =>
         !h.includes('#inbox/') && !h.includes('#sent/') && !h.includes('#search/') },
@@ -1040,7 +1108,6 @@ async function renderStaticDashboard() {
     { hostname: 'www.linkedin.com',    pathExact: ['/'] },
     { hostname: 'github.com',          pathExact: ['/'] },
     { hostname: 'www.youtube.com',     pathExact: ['/'] },
-    // Merge personal patterns from config.local.js (if it exists)
     ...(typeof LOCAL_LANDING_PAGE_PATTERNS !== 'undefined' ? LOCAL_LANDING_PAGE_PATTERNS : []),
   ];
 
@@ -1048,7 +1115,6 @@ async function renderStaticDashboard() {
     try {
       const parsed = new URL(url);
       return LANDING_PAGE_PATTERNS.some(p => {
-        // Support both exact hostname and suffix matching (for wildcard subdomains)
         const hostnameMatch = p.hostname
           ? parsed.hostname === p.hostname
           : p.hostnameEndsWith
@@ -1067,10 +1133,8 @@ async function renderStaticDashboard() {
   const groupMap    = {};
   const landingTabs = [];
 
-  // Custom group rules from config.local.js (if any)
   const customGroups = typeof LOCAL_CUSTOM_GROUPS !== 'undefined' ? LOCAL_CUSTOM_GROUPS : [];
 
-  // Check if a URL matches a custom group rule; returns the rule or null
   function matchCustomGroup(url) {
     try {
       const parsed = new URL(url);
@@ -1082,7 +1146,7 @@ async function renderStaticDashboard() {
             : false;
         if (!hostMatch) return false;
         if (r.pathPrefix) return parsed.pathname.startsWith(r.pathPrefix);
-        return true; // hostname matched, no path filter
+        return true;
       }) || null;
     } catch { return null; }
   }
@@ -1093,8 +1157,6 @@ async function renderStaticDashboard() {
         landingTabs.push(tab);
         continue;
       }
-
-      // Check custom group rules first (e.g. merge subdomains, split by path)
       const customRule = matchCustomGroup(tab.url);
       if (customRule) {
         const key = customRule.groupKey;
@@ -1102,7 +1164,6 @@ async function renderStaticDashboard() {
         groupMap[key].tabs.push(tab);
         continue;
       }
-
       let hostname;
       if (tab.url && tab.url.startsWith('file://')) {
         hostname = 'local-files';
@@ -1110,20 +1171,15 @@ async function renderStaticDashboard() {
         hostname = new URL(tab.url).hostname;
       }
       if (!hostname) continue;
-
       if (!groupMap[hostname]) groupMap[hostname] = { domain: hostname, tabs: [] };
       groupMap[hostname].tabs.push(tab);
-    } catch {
-      // Skip malformed URLs
-    }
+    } catch { /* skip malformed URLs */ }
   }
 
   if (landingTabs.length > 0) {
     groupMap['__landing-pages__'] = { domain: '__landing-pages__', tabs: landingTabs };
   }
 
-  // Sort: landing pages first, then domains from landing page sites, then by tab count
-  // Collect exact hostnames and suffix patterns for priority sorting
   const landingHostnames = new Set(LANDING_PAGE_PATTERNS.map(p => p.hostname).filter(Boolean));
   const landingSuffixes = LANDING_PAGE_PATTERNS.map(p => p.hostnameEndsWith).filter(Boolean);
   function isLandingDomain(domain) {
@@ -1134,15 +1190,13 @@ async function renderStaticDashboard() {
     const aIsLanding = a.domain === '__landing-pages__';
     const bIsLanding = b.domain === '__landing-pages__';
     if (aIsLanding !== bIsLanding) return aIsLanding ? -1 : 1;
-
     const aIsPriority = isLandingDomain(a.domain);
     const bIsPriority = isLandingDomain(b.domain);
     if (aIsPriority !== bIsPriority) return aIsPriority ? -1 : 1;
-
     return b.tabs.length - a.tabs.length;
   });
 
-  // --- Render domain cards ---
+  // Render
   const openTabsSection      = document.getElementById('openTabsSection');
   const openTabsMissionsEl   = document.getElementById('openTabsMissions');
   const openTabsSectionCount = document.getElementById('openTabsSectionCount');
@@ -1150,11 +1204,250 @@ async function renderStaticDashboard() {
 
   if (domainGroups.length > 0 && openTabsSection) {
     if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-    openTabsSectionCount.innerHTML = `${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&middot;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
+    openTabsSectionCount.innerHTML = `${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
     openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
     openTabsSection.style.display = 'block';
   } else if (openTabsSection) {
     openTabsSection.style.display = 'none';
+  }
+}
+
+/**
+ * renderGroupView()
+ *
+ * Renders the Chrome tab group view:
+ * 1. Chrome groups as cards (with color accent bars)
+ * 2. Ungrouped tabs as a lightweight "Not grouped" chip cluster
+ */
+async function renderGroupView(viewMode) {
+  const openTabsSection      = document.getElementById('openTabsSection');
+  const openTabsMissionsEl = document.getElementById('openTabsMissions');
+  const openTabsSectionCount = document.getElementById('openTabsSectionCount');
+  const openTabsSectionTitle = document.getElementById('openTabsSectionTitle');
+  if (!openTabsSection) return;
+
+  const realTabs = getRealTabs();
+
+  // Partition tabs: grouped (groupId >= 0) vs ungrouped (groupId === -1)
+  const groupedTabs   = realTabs.filter(t => t.groupId >= 0);
+  const ungroupedTabs = realTabs.filter(t => t.groupId === -1);
+
+  // Build group data: map<groupId, { groupInfo, tabs[] }>
+  const groupData = new Map();
+  for (const group of tabGroupsList) {
+    groupData.set(group.id, { groupInfo: group, tabs: [] });
+  }
+  for (const tab of groupedTabs) {
+    if (groupData.has(tab.groupId)) {
+      groupData.get(tab.groupId).tabs.push(tab);
+    }
+  }
+
+  // Sort groups by minimum tab.index (Chrome's visual order)
+  const sortedGroups = Array.from(groupData.values())
+    .filter(g => g.tabs.length > 0)
+    .sort((a, b) => {
+      const aMin = Math.min(...a.tabs.map(t => t.index));
+      const bMin = Math.min(...b.tabs.map(t => t.index));
+      return aMin - bMin;
+    });
+
+  const groupCount = sortedGroups.length;
+  const ungroupedCount = ungroupedTabs.length;
+
+  // Render section header with toggle + count
+  if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
+  const closeAllId = 'close-all-open-tabs-group';
+  openTabsSectionCount.innerHTML = `
+    <span class="view-toggle">
+      <button class="toggle-pill ${viewMode === 'group' ? 'active' : ''}" data-action="switch-view" data-view="group">Groups</button>
+      <button class="toggle-pill" data-action="switch-view" data-view="domain">Domains</button>
+    </span>
+    &nbsp;&nbsp;${groupCount} group${groupCount !== 1 ? 's' : ''}${ungroupedCount > 0 ? ` · ${ungroupedCount} ungrouped` : ''}
+    &nbsp;&nbsp;<button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
+
+  // Render group cards + ungrouped section
+  let html = '';
+
+  for (const { groupInfo, tabs } of sortedGroups) {
+    html += renderTabGroupCard(groupInfo, tabs);
+  }
+
+  if (ungroupedTabs.length > 0) {
+    html += renderUngroupedSection(ungroupedTabs);
+  }
+
+  if (sortedGroups.length > 0 || ungroupedTabs.length > 0) {
+    openTabsMissionsEl.innerHTML = html;
+    openTabsSection.style.display = 'block';
+  } else {
+    openTabsMissionsEl.innerHTML = '';
+    openTabsSection.style.display = 'none';
+  }
+}
+
+/**
+ * renderTabGroupCard(groupInfo, tabs)
+ *
+ * Renders a Chrome tab group as a card, similar to renderDomainCard().
+ * Uses the group color for the status bar. Same chip structure as domain cards.
+ */
+function renderTabGroupCard(groupInfo, tabs) {
+  const color  = CHROME_GROUP_COLORS[groupInfo.color] || '#5f6368';
+  const name   = groupInfo.title || '(unnamed)';
+  const tabCount = tabs.length;
+
+  const { urlCounts, uniqueTabs, hasDupes, totalExtras, dupeUrls } = detectDuplicateTabs(tabs);
+
+  const tabBadge = `<span class="open-tabs-badge">
+    ${ICONS.tabs}
+    ${tabCount} tab${tabCount !== 1 ? 's' : ''} open
+  </span>`;
+
+  const dupeBadge = hasDupes
+    ? `<span class="open-tabs-badge" style="color:var(--accent-amber);background:rgba(200,113,58,0.08);">
+        ${totalExtras} duplicate${totalExtras !== 1 ? 's' : ''}
+      </span>`
+    : '';
+
+  const visibleTabs  = uniqueTabs.slice(0, 8);
+  const extraCount  = uniqueTabs.length - visibleTabs.length;
+
+  const pageChips = visibleTabs.map(tab => {
+    const label    = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
+    const count    = urlCounts[tab.url];
+    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
+    const chipClass = count > 1 ? ' chip-has-dupes' : '';
+    const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
+    const safeTitle = label.replace(/"/g, '&quot;');
+    let domain = '';
+    try { domain = new URL(tab.url).hostname; } catch {}
+    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+    return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+      <span class="chip-text">${label}</span>${dupeTag}
+      <div class="chip-actions">
+        <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
+        </button>
+        <button class="chip-action chip-close" data-action="close-single-tab" data-tab-url="${safeUrl}" title="Close this tab">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+        </button>
+      </div>
+    </div>`;
+  }).join('') + (extraCount > 0 ? buildOverflowChips(uniqueTabs.slice(8), urlCounts) : '');
+
+  const tabIds = tabs.map(t => t.id);
+  let actionsHtml = `
+    <button class="action-btn close-tabs" data-action="close-group-tabs" data-group-id="${groupInfo.id}">
+      ${ICONS.close}
+      Close all ${tabCount} tab${tabCount !== 1 ? 's' : ''}
+    </button>
+    <button class="action-btn" data-action="ungroup-tabs" data-group-id="${groupInfo.id}" style="color:var(--accent-blue);">
+      Ungroup
+    </button>`;
+
+  if (hasDupes) {
+    const dupeUrlsEncoded = dupeUrls.map(([url]) => encodeURIComponent(url)).join(',');
+    actionsHtml += `
+      <button class="action-btn" data-action="dedup-keep-one" data-dupe-urls="${dupeUrlsEncoded}">
+        Close ${totalExtras} duplicate${totalExtras !== 1 ? 's' : ''}
+      </button>`;
+  }
+
+  const stableId = 'group-' + String(groupInfo.id);
+
+  return `
+    <div class="mission-card group-card" data-group-id="${stableId}">
+      <div class="status-bar" style="background:${color}"></div>
+      <div class="mission-content">
+        <div class="mission-top">
+          <span class="mission-name">${name}</span>
+          ${tabBadge}
+          ${dupeBadge}
+        </div>
+        <div class="mission-pages">${pageChips}</div>
+        <div class="actions">${actionsHtml}</div>
+      </div>
+      <div class="mission-meta">
+        <div class="mission-page-count">${tabCount}</div>
+        <div class="mission-page-label">tabs</div>
+      </div>
+    </div>`;
+}
+
+/**
+ * renderUngroupedSection(ungroupedTabs)
+ *
+ * Lightweight chip cluster for ungrouped tabs in group view.
+ * NOT a full domain card — just a labeled chip section.
+ */
+function renderUngroupedSection(ungroupedTabs) {
+  const { urlCounts, uniqueTabs } = detectDuplicateTabs(ungroupedTabs);
+
+  const chips = uniqueTabs.map(tab => {
+    const label    = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
+    const count    = urlCounts[tab.url];
+    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
+    const chipClass = count > 1 ? ' chip-has-dupes' : '';
+    const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
+    const safeTitle = label.replace(/"/g, '&quot;');
+    let domain = '';
+    try { domain = new URL(tab.url).hostname; } catch {}
+    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+    return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+      <span class="chip-text">${label}</span>${dupeTag}
+      <div class="chip-actions">
+        <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
+        </button>
+        <button class="chip-action chip-close" data-action="close-single-tab" data-tab-url="${safeUrl}" title="Close this tab">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+        </button>
+      </div>
+    </div>`;
+  }).join('');
+
+  return `
+    <div class="ungrouped-section">
+      <div class="ungrouped-label">Not grouped</div>
+      <div class="ungrouped-chips">${chips}</div>
+    </div>`;
+}
+
+/**
+ * renderStaticDashboard()
+ *
+ * The main render function:
+ * 1. Paints greeting + date
+ * 2. Fetches open tabs and tab groups via chrome APIs
+ * 3. Branches to group view or domain view based on viewMode
+ * 4. Updates footer stats
+ * 5. Renders the "Saved for Later" checklist
+ * 6. Sets up 30-second auto-refresh
+ */
+async function renderStaticDashboard() {
+  // --- Header ---
+  const greetingEl = document.getElementById('greeting');
+  const dateEl     = document.getElementById('dateDisplay');
+  if (greetingEl) greetingEl.textContent = getGreeting();
+  if (dateEl)     dateEl.textContent     = getDateDisplay();
+
+  // --- Fetch tabs + tab groups in parallel ---
+  await Promise.all([fetchOpenTabs(), fetchTabGroups()]);
+  const realTabs = getRealTabs();
+
+  // --- Determine view mode ---
+  // If no Chrome groups exist, force domain view and hide the toggle.
+  const storedView    = await loadViewMode();
+  const effectiveView  = (tabGroupsList.length === 0) ? 'domain' : storedView;
+
+  // --- Branch on view mode ---
+  if (effectiveView === 'group') {
+    await renderGroupView(effectiveView);
+  } else {
+    await renderDomainView(realTabs);
   }
 
   // --- Footer stats ---
@@ -1166,6 +1459,20 @@ async function renderStaticDashboard() {
 
   // --- Render "Saved for Later" column ---
   await renderDeferredColumn();
+
+  // --- 30-second auto-refresh (clears stale group state) ---
+  if (window._tabOutRefreshTimer) clearInterval(window._tabOutRefreshTimer);
+  window._tabOutRefreshTimer = setInterval(async () => {
+    await Promise.all([fetchOpenTabs(), fetchTabGroups()]);
+    const stored = await loadViewMode();
+    const view   = (tabGroupsList.length === 0) ? 'domain' : stored;
+    if (view === 'group') {
+      await renderGroupView(view);
+    } else {
+      await renderDomainView(getRealTabs());
+    }
+    if (statTabs) statTabs.textContent = openTabs.length;
+  }, 30000);
 }
 
 async function renderDashboard() {
@@ -1412,6 +1719,46 @@ document.addEventListener('click', async (e) => {
     return;
   }
 
+  // ---- Switch view mode (Groups <-> Domains) ----
+  if (action === 'switch-view') {
+    const newView = actionEl.dataset.view;
+    await saveViewMode(newView);
+    await renderDashboard();
+    return;
+  }
+
+  // ---- Close all tabs in a Chrome tab group ----
+  if (action === 'close-group-tabs') {
+    const groupId = Number(actionEl.dataset.groupId);
+    const groupTabs = openTabs.filter(t => t.groupId === groupId);
+    const tabIds = groupTabs.map(t => t.id);
+    await closeTabsByIds(tabIds);
+    playCloseSound();
+    const card = document.querySelector(`[data-group-id="group-${groupId}"]`);
+    if (card) {
+      const rect = card.getBoundingClientRect();
+      shootConfetti(rect.left + rect.width / 2, rect.top + rect.height / 2);
+      animateCardOut(card);
+    }
+    const statTabs = document.getElementById('statTabs');
+    if (statTabs) statTabs.textContent = openTabs.length;
+    showToast(`Closed ${tabIds.length} tab${tabIds.length !== 1 ? 's' : ''} from group`);
+    return;
+  }
+
+  // ---- Ungroup a Chrome tab group (move tabs out) ----
+  if (action === 'ungroup-tabs') {
+    const groupId = Number(actionEl.dataset.groupId);
+    const groupTabs = openTabs.filter(t => t.groupId === groupId);
+    for (const tab of groupTabs) {
+      try { await chrome.tabs.ungroup(tab.id); } catch { /* already closed or ungrouped */ }
+    }
+    await fetchOpenTabs();
+    await renderDashboard();
+    showToast(`Ungrouped ${groupTabs.length} tab${groupTabs.length !== 1 ? 's' : ''}`);
+    return;
+  }
+
   // ---- Close ALL open tabs ----
   if (action === 'close-all-open-tabs') {
     const allUrls = openTabs
@@ -1475,6 +1822,22 @@ document.addEventListener('input', async (e) => {
   }
 });
 
+
+/* ----------------------------------------------------------------
+   KEYBOARD SHORTCUTS
+   ---------------------------------------------------------------- */
+
+// Ctrl/Cmd + Shift + G — toggle between group and domain view
+document.addEventListener('keydown', async (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'G') {
+    e.preventDefault();
+    const stored = await loadViewMode();
+    const current = (tabGroupsList.length === 0) ? 'domain' : stored;
+    const next = current === 'group' ? 'domain' : 'group';
+    await saveViewMode(next);
+    await renderDashboard();
+  }
+});
 
 /* ----------------------------------------------------------------
    INITIALIZE

--- a/extension/app.js
+++ b/extension/app.js
@@ -871,14 +871,14 @@ const ICON_WINDOW = `<svg class="chip-protected-icon chip-window-icon" xmlns="ht
  * buildPageChip(tab, label, urlCounts, domainHint)
  *
  * Builds one tab chip row HTML. Handles pinned/standalone-window visual treatment.
- * Protected tabs get a badge icon and no close button.
+ * Protected tabs show a badge icon before the favicon, and keep the close button
+ * (individual close still works; only bulk "Close all" skips them).
  */
 function buildPageChip(tab, label, urlCounts, domainHint = '') {
   const count     = urlCounts[tab.url] || 1;
   const dupeTag   = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
   const isPinned  = tab.pinned;
   const isAlone   = tab.isAloneInWindow;
-  const protected_ = isPinned || isAlone;
 
   let chipClass = '';
   if (count > 1)  chipClass += ' chip-has-dupes';
@@ -891,20 +891,24 @@ function buildPageChip(tab, label, urlCounts, domainHint = '') {
   try { domain = new URL(tab.url).hostname; } catch {}
   const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
 
-  const protectedBadge = isPinned ? ICON_PIN : (isAlone ? ICON_WINDOW : '');
-
-  const closeBtn = protected_ ? '' : `
-        <button class="chip-action chip-close" data-action="close-single-tab" data-tab-url="${safeUrl}" title="Close this tab">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
-        </button>`;
+  // Badge overlaid on favicon corner — no extra horizontal space, rows stay aligned
+  const badgeOverlay = isPinned
+    ? ICON_PIN
+    : (isAlone ? ICON_WINDOW : '');
+  const faviconHtml = faviconUrl
+    ? `<span class="chip-favicon-wrap">${badgeOverlay}<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'"></span>`
+    : (badgeOverlay ? `<span class="chip-favicon-wrap chip-favicon-wrap--no-img">${badgeOverlay}</span>` : '');
 
   return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}${protectedBadge}
+      ${faviconHtml}
+      <span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
-        </button>${closeBtn}
+        </button>
+        <button class="chip-action chip-close" data-action="close-single-tab" data-tab-url="${safeUrl}" title="Close this tab">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+        </button>
       </div>
     </div>`;
 }
@@ -1267,8 +1271,12 @@ async function renderDomainView(realTabs) {
 
   if (domainGroups.length > 0 && openTabsSection) {
     if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-    const closableCount = realTabs.filter(t => !isProtectedTab(t)).length;
-    openTabsSectionCount.innerHTML = `${buildViewToggle('domain')}${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''}${closableCount > 0 ? ` &nbsp;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${closableCount} tabs</button>` : ''}`;
+    const closableCount  = realTabs.filter(t => !isProtectedTab(t)).length;
+    const protectedCount = realTabs.length - closableCount;
+    const closeAllTooltip = protectedCount > 0
+      ? `Closes ${closableCount} tab${closableCount !== 1 ? 's' : ''}. Skips ${protectedCount} pinned/window tab${protectedCount !== 1 ? 's' : ''} — safe to use!`
+      : `Close all ${closableCount} tabs`;
+    openTabsSectionCount.innerHTML = `${buildViewToggle('domain')}${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''}${closableCount > 0 ? ` &nbsp;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;" title="${closeAllTooltip}">${ICONS.close} Close all ${closableCount} tabs</button>` : ''}`;
     openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
     openTabsSection.style.display = 'block';
   } else if (openTabsSection) {
@@ -1321,8 +1329,12 @@ async function renderGroupView() {
 
   // Render section header with toggle + count
   if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-  const closableCount = realTabs.filter(t => !isProtectedTab(t)).length;
-  openTabsSectionCount.innerHTML = `${buildViewToggle('group')}${groupCount} group${groupCount !== 1 ? 's' : ''}${ungroupedCount > 0 ? ` · ${ungroupedCount} ungrouped` : ''}${closableCount > 0 ? ` &nbsp;&nbsp;<button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${closableCount} tabs</button>` : ''}`;
+  const closableCount  = realTabs.filter(t => !isProtectedTab(t)).length;
+  const protectedCount = realTabs.length - closableCount;
+  const closeAllTooltip = protectedCount > 0
+    ? `Closes ${closableCount} tab${closableCount !== 1 ? 's' : ''}. Skips ${protectedCount} pinned/window tab${protectedCount !== 1 ? 's' : ''} — safe to use!`
+    : `Close all ${closableCount} tabs`;
+  openTabsSectionCount.innerHTML = `${buildViewToggle('group')}${groupCount} group${groupCount !== 1 ? 's' : ''}${ungroupedCount > 0 ? ` · ${ungroupedCount} ungrouped` : ''}${closableCount > 0 ? ` &nbsp;&nbsp;<button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;" title="${closeAllTooltip}">${ICONS.close} Close all ${closableCount} tabs</button>` : ''}`;
 
   // Render group cards + ungrouped section
   let html = '';
@@ -1554,12 +1566,10 @@ document.addEventListener('click', async (e) => {
     const tabUrl = actionEl.dataset.tabUrl;
     if (!tabUrl) return;
 
-    // Close the tab in Chrome directly (skip protected tabs)
+    // Close the tab in Chrome directly — single close has no restrictions
     const allTabs = await chrome.tabs.query({});
-    const tabsPerWindow = {};
-    for (const t of allTabs) tabsPerWindow[t.windowId] = (tabsPerWindow[t.windowId] || 0) + 1;
     const match = allTabs.find(t => t.url === tabUrl);
-    if (match && !match.pinned && tabsPerWindow[match.windowId] !== 1) await chrome.tabs.remove(match.id);
+    if (match) await chrome.tabs.remove(match.id);
     await fetchOpenTabs();
 
     playCloseSound();

--- a/extension/app.js
+++ b/extension/app.js
@@ -1629,13 +1629,20 @@ document.addEventListener('click', async (e) => {
     if (match) await chrome.tabs.remove(match.id);
     await fetchOpenTabs();
 
-    // Animate chip out
+    // Animate chip out, then remove card if empty
     const chip = actionEl.closest('.page-chip');
     if (chip) {
       chip.style.transition = 'opacity 0.2s, transform 0.2s';
       chip.style.opacity    = '0';
       chip.style.transform  = 'scale(0.8)';
-      setTimeout(() => chip.remove(), 200);
+      setTimeout(() => {
+        chip.remove();
+        document.querySelectorAll('.mission-card').forEach(c => {
+          if (c.querySelectorAll('.page-chip[data-action="focus-tab"]').length === 0) {
+            animateCardOut(c);
+          }
+        });
+      }, 200);
     }
 
     showToast('Saved for later');

--- a/extension/app.js
+++ b/extension/app.js
@@ -1204,7 +1204,8 @@ async function renderDomainView(realTabs) {
 
   if (domainGroups.length > 0 && openTabsSection) {
     if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-    openTabsSectionCount.innerHTML = `${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
+    const toggleHtml = tabGroupsList.length > 0 ? `<span class="view-toggle"><button class="toggle-pill" data-action="switch-view" data-view="group">Groups</button><button class="toggle-pill active" data-action="switch-view" data-view="domain">Domains</button></span>&nbsp;&nbsp;` : '';
+    openTabsSectionCount.innerHTML = `${toggleHtml}${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
     openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
     openTabsSection.style.display = 'block';
   } else if (openTabsSection) {

--- a/extension/app.js
+++ b/extension/app.js
@@ -558,6 +558,10 @@ function checkAndShowEmptyState() {
   const remaining = missionsEl.querySelectorAll('.mission-card:not(.closing)').length;
   if (remaining > 0) return;
 
+  // Also check actual tab data — DOM cards may be animating out while real tabs still exist
+  const realTabsRemaining = openTabs.filter(t => !isProtectedTab(t)).length;
+  if (realTabsRemaining > 0) return;
+
   missionsEl.innerHTML = `
     <div class="missions-empty-state">
       <div class="empty-checkmark">
@@ -1764,17 +1768,16 @@ document.addEventListener('click', async (e) => {
     const groupId = Number(actionEl.dataset.groupId);
     const groupTabs = openTabs.filter(t => t.groupId === groupId);
     const tabIds = groupTabs.map(t => t.id);
-    await closeTabsByIds(tabIds);
-    playCloseSound();
+    // Shoot confetti before closing so card is still in DOM
     const card = document.querySelector(`[data-group-id="group-${groupId}"]`);
     if (card) {
       const rect = card.getBoundingClientRect();
       shootConfetti(rect.left + rect.width / 2, rect.top + rect.height / 2);
-      animateCardOut(card);
     }
-    const statTabs = document.getElementById('statTabs');
-    if (statTabs) statTabs.textContent = openTabs.length;
+    await closeTabsByIds(tabIds);
+    playCloseSound();
     showToast(`Closed ${tabIds.length} tab${tabIds.length !== 1 ? 's' : ''} from group`);
+    await renderDashboard();
     return;
   }
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -42,13 +42,20 @@ async function fetchOpenTabs() {
     const newtabUrl = `chrome-extension://${extensionId}/index.html`;
 
     const tabs = await chrome.tabs.query({});
+
+    // Count tabs per window to detect "alone in window" (popup/standalone windows)
+    const tabsPerWindow = {};
+    for (const t of tabs) tabsPerWindow[t.windowId] = (tabsPerWindow[t.windowId] || 0) + 1;
+
     openTabs = tabs.map(t => ({
-      id:       t.id,
-      url:      t.url,
-      title:    t.title,
-      windowId: t.windowId,
-      active:   t.active,
-      groupId:  t.groupId,  // -1 = ungrouped, >= 0 = Chrome tab group id
+      id:              t.id,
+      url:             t.url,
+      title:           t.title,
+      windowId:        t.windowId,
+      active:          t.active,
+      groupId:         t.groupId,  // -1 = ungrouped, >= 0 = Chrome tab group id
+      pinned:          t.pinned,
+      isAloneInWindow: tabsPerWindow[t.windowId] === 1,
       // Flag Tab Out's own pages so we can detect duplicate new tabs
       isTabOut: t.url === newtabUrl || t.url === 'chrome://newtab/',
     }));
@@ -56,6 +63,17 @@ async function fetchOpenTabs() {
     // chrome.tabs API unavailable (shouldn't happen in an extension page)
     openTabs = [];
   }
+}
+
+/**
+ * isProtectedTab(tab)
+ *
+ * Returns true for tabs that should never be bulk-closed:
+ * - Pinned tabs (Chrome protects these from accidental close)
+ * - Tabs that are the sole tab in their window (closing would close the window)
+ */
+function isProtectedTab(tab) {
+  return tab.pinned || tab.isAloneInWindow;
 }
 
 /**
@@ -82,9 +100,15 @@ async function closeTabsByUrls(urls) {
     }
   }
 
+  // Count tabs per window so we can skip lone-window tabs
   const allTabs = await chrome.tabs.query({});
+  const tabsPerWindow = {};
+  for (const t of allTabs) tabsPerWindow[t.windowId] = (tabsPerWindow[t.windowId] || 0) + 1;
+
   const toClose = allTabs
     .filter(tab => {
+      if (tab.pinned) return false;
+      if (tabsPerWindow[tab.windowId] === 1) return false;
       const tabUrl = tab.url || '';
       if (tabUrl.startsWith('file://') && exactUrls.has(tabUrl)) return true;
       try {
@@ -108,7 +132,11 @@ async function closeTabsExact(urls) {
   if (!urls || urls.length === 0) return;
   const urlSet = new Set(urls);
   const allTabs = await chrome.tabs.query({});
-  const toClose = allTabs.filter(t => urlSet.has(t.url)).map(t => t.id);
+  const tabsPerWindow = {};
+  for (const t of allTabs) tabsPerWindow[t.windowId] = (tabsPerWindow[t.windowId] || 0) + 1;
+  const toClose = allTabs
+    .filter(t => urlSet.has(t.url) && !t.pinned && tabsPerWindow[t.windowId] !== 1)
+    .map(t => t.id);
   if (toClose.length > 0) await chrome.tabs.remove(toClose);
   await fetchOpenTabs();
 }
@@ -121,7 +149,11 @@ async function closeTabsExact(urls) {
  */
 async function closeTabsByIds(ids) {
   if (!ids || ids.length === 0) return;
-  await chrome.tabs.remove(ids);
+  // Filter out protected tabs (pinned or alone in their window)
+  const safeIds = openTabs
+    .filter(t => ids.includes(t.id) && !isProtectedTab(t))
+    .map(t => t.id);
+  if (safeIds.length > 0) await chrome.tabs.remove(safeIds);
   await fetchOpenTabs();
 }
 
@@ -826,32 +858,66 @@ function checkTabOutDupes() {
 
 
 /* ----------------------------------------------------------------
+   CHIP BUILDER — shared helper for all tab chip rows
+   ---------------------------------------------------------------- */
+
+// Pin icon SVG (small, inline)
+const ICON_PIN = `<svg class="chip-protected-icon chip-pin-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" aria-label="Pinned tab"><path d="M9.828.722a.5.5 0 0 1 .354.146l4.95 4.95a.5.5 0 0 1 0 .707c-.48.48-1.072.588-1.503.588-.177 0-.335-.018-.46-.039l-3.134 3.134a5.927 5.927 0 0 1 .16 1.013c.046.702-.032 1.687-.72 2.375a.5.5 0 0 1-.707 0l-2.829-2.828-3.182 3.182c-.195.195-1.219.902-1.414.707-.195-.195.512-1.22.707-1.414l3.182-3.182-2.828-2.829a.5.5 0 0 1 0-.707c.688-.688 1.673-.767 2.375-.72a5.922 5.922 0 0 1 1.013.16l3.134-3.133a2.772 2.772 0 0 1-.04-.461c0-.43.108-1.022.589-1.503a.5.5 0 0 1 .353-.146z"/></svg>`;
+
+// Standalone window icon SVG (small, inline)
+const ICON_WINDOW = `<svg class="chip-protected-icon chip-window-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-label="Standalone window"><rect x="1.5" y="3" width="13" height="10" rx="1.5"/><line x1="1.5" y1="6" x2="14.5" y2="6"/><circle cx="4" cy="4.5" r="0.6" fill="currentColor" stroke="none"/><circle cx="6.2" cy="4.5" r="0.6" fill="currentColor" stroke="none"/></svg>`;
+
+/**
+ * buildPageChip(tab, label, urlCounts, domainHint)
+ *
+ * Builds one tab chip row HTML. Handles pinned/standalone-window visual treatment.
+ * Protected tabs get a badge icon and no close button.
+ */
+function buildPageChip(tab, label, urlCounts, domainHint = '') {
+  const count     = urlCounts[tab.url] || 1;
+  const dupeTag   = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
+  const isPinned  = tab.pinned;
+  const isAlone   = tab.isAloneInWindow;
+  const protected_ = isPinned || isAlone;
+
+  let chipClass = '';
+  if (count > 1)  chipClass += ' chip-has-dupes';
+  if (isPinned)   chipClass += ' chip-pinned';
+  if (isAlone)    chipClass += ' chip-alone-window';
+
+  const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
+  const safeTitle = label.replace(/"/g, '&quot;');
+  let domain = '';
+  try { domain = new URL(tab.url).hostname; } catch {}
+  const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+
+  const protectedBadge = isPinned ? ICON_PIN : (isAlone ? ICON_WINDOW : '');
+
+  const closeBtn = protected_ ? '' : `
+        <button class="chip-action chip-close" data-action="close-single-tab" data-tab-url="${safeUrl}" title="Close this tab">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+        </button>`;
+
+  return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+      <span class="chip-text">${label}</span>${dupeTag}${protectedBadge}
+      <div class="chip-actions">
+        <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
+        </button>${closeBtn}
+      </div>
+    </div>`;
+}
+
+
+/* ----------------------------------------------------------------
    OVERFLOW CHIPS ("+N more" expand button in domain cards)
    ---------------------------------------------------------------- */
 
 function buildOverflowChips(hiddenTabs, urlCounts = {}) {
   const hiddenChips = hiddenTabs.map(tab => {
-    const label    = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
-    const count    = urlCounts[tab.url] || 1;
-    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
-    const chipClass = count > 1 ? ' chip-has-dupes' : '';
-    const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
-    const safeTitle = label.replace(/"/g, '&quot;');
-    let domain = '';
-    try { domain = new URL(tab.url).hostname; } catch {}
-    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
-    return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}
-      <div class="chip-actions">
-        <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
-        </button>
-        <button class="chip-action chip-close" data-action="close-single-tab" data-tab-url="${safeUrl}" title="Close this tab">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
-        </button>
-      </div>
-    </div>`;
+    const label = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
+    return buildPageChip(tab, label, urlCounts);
   }).join('');
 
   return `
@@ -913,33 +979,15 @@ function renderDomainCard(group) {
       const parsed = new URL(tab.url);
       if (parsed.hostname === 'localhost' && parsed.port) label = `${parsed.port} ${label}`;
     } catch {}
-    const count    = urlCounts[tab.url];
-    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
-    const chipClass = count > 1 ? ' chip-has-dupes' : '';
-    const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
-    const safeTitle = label.replace(/"/g, '&quot;');
-    let domain = '';
-    try { domain = new URL(tab.url).hostname; } catch {}
-    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
-    return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}
-      <div class="chip-actions">
-        <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
-        </button>
-        <button class="chip-action chip-close" data-action="close-single-tab" data-tab-url="${safeUrl}" title="Close this tab">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
-        </button>
-      </div>
-    </div>`;
+    return buildPageChip(tab, label, urlCounts, group.domain);
   }).join('') + (extraCount > 0 ? buildOverflowChips(uniqueTabs.slice(8), urlCounts) : '');
 
-  let actionsHtml = `
+  const closableCount = tabs.filter(t => !isProtectedTab(t)).length;
+  let actionsHtml = closableCount > 0 ? `
     <button class="action-btn close-tabs" data-action="close-domain-tabs" data-domain-id="${stableId}">
       ${ICONS.close}
-      Close all ${tabCount} tab${tabCount !== 1 ? 's' : ''}
-    </button>`;
+      Close ${closableCount} tab${closableCount !== 1 ? 's' : ''}
+    </button>` : '';
 
   if (hasDupes) {
     const dupeUrlsEncoded = dupeUrls.map(([url]) => encodeURIComponent(url)).join(',');
@@ -1219,7 +1267,8 @@ async function renderDomainView(realTabs) {
 
   if (domainGroups.length > 0 && openTabsSection) {
     if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-    openTabsSectionCount.innerHTML = `${buildViewToggle('domain')}${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
+    const closableCount = realTabs.filter(t => !isProtectedTab(t)).length;
+    openTabsSectionCount.innerHTML = `${buildViewToggle('domain')}${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''}${closableCount > 0 ? ` &nbsp;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${closableCount} tabs</button>` : ''}`;
     openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
     openTabsSection.style.display = 'block';
   } else if (openTabsSection) {
@@ -1272,7 +1321,8 @@ async function renderGroupView() {
 
   // Render section header with toggle + count
   if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-  openTabsSectionCount.innerHTML = `${buildViewToggle('group')}${groupCount} group${groupCount !== 1 ? 's' : ''}${ungroupedCount > 0 ? ` · ${ungroupedCount} ungrouped` : ''} &nbsp;&nbsp;<button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
+  const closableCount = realTabs.filter(t => !isProtectedTab(t)).length;
+  openTabsSectionCount.innerHTML = `${buildViewToggle('group')}${groupCount} group${groupCount !== 1 ? 's' : ''}${ungroupedCount > 0 ? ` · ${ungroupedCount} ungrouped` : ''}${closableCount > 0 ? ` &nbsp;&nbsp;<button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${closableCount} tabs</button>` : ''}`;
 
   // Render group cards + ungrouped section
   let html = '';
@@ -1322,35 +1372,16 @@ function renderTabGroupCard(groupInfo, tabs) {
   const extraCount  = uniqueTabs.length - visibleTabs.length;
 
   const pageChips = visibleTabs.map(tab => {
-    const label    = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
-    const count    = urlCounts[tab.url];
-    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
-    const chipClass = count > 1 ? ' chip-has-dupes' : '';
-    const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
-    const safeTitle = label.replace(/"/g, '&quot;');
-    let domain = '';
-    try { domain = new URL(tab.url).hostname; } catch {}
-    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
-    return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}
-      <div class="chip-actions">
-        <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
-        </button>
-        <button class="chip-action chip-close" data-action="close-single-tab" data-tab-url="${safeUrl}" title="Close this tab">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
-        </button>
-      </div>
-    </div>`;
+    const label = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
+    return buildPageChip(tab, label, urlCounts);
   }).join('') + (extraCount > 0 ? buildOverflowChips(uniqueTabs.slice(8), urlCounts) : '');
 
-  const tabIds = tabs.map(t => t.id);
-  let actionsHtml = `
+  const closableCount = tabs.filter(t => !isProtectedTab(t)).length;
+  let actionsHtml = (closableCount > 0 ? `
     <button class="action-btn close-tabs" data-action="close-group-tabs" data-group-id="${groupInfo.id}">
       ${ICONS.close}
-      Close all ${tabCount} tab${tabCount !== 1 ? 's' : ''}
-    </button>
+      Close ${closableCount} tab${closableCount !== 1 ? 's' : ''}
+    </button>` : '') + `
     <button class="action-btn" data-action="ungroup-tabs" data-group-id="${groupInfo.id}" style="color:var(--accent-blue);">
       Ungroup
     </button>`;
@@ -1394,27 +1425,8 @@ function renderUngroupedSection(ungroupedTabs) {
   const { urlCounts, uniqueTabs } = detectDuplicateTabs(ungroupedTabs);
 
   const chips = uniqueTabs.map(tab => {
-    const label    = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
-    const count    = urlCounts[tab.url];
-    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
-    const chipClass = count > 1 ? ' chip-has-dupes' : '';
-    const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
-    const safeTitle = label.replace(/"/g, '&quot;');
-    let domain = '';
-    try { domain = new URL(tab.url).hostname; } catch {}
-    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
-    return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}
-      <div class="chip-actions">
-        <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
-        </button>
-        <button class="chip-action chip-close" data-action="close-single-tab" data-tab-url="${safeUrl}" title="Close this tab">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
-        </button>
-      </div>
-    </div>`;
+    const label = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
+    return buildPageChip(tab, label, urlCounts);
   }).join('');
 
   return `
@@ -1542,10 +1554,12 @@ document.addEventListener('click', async (e) => {
     const tabUrl = actionEl.dataset.tabUrl;
     if (!tabUrl) return;
 
-    // Close the tab in Chrome directly
+    // Close the tab in Chrome directly (skip protected tabs)
     const allTabs = await chrome.tabs.query({});
-    const match   = allTabs.find(t => t.url === tabUrl);
-    if (match) await chrome.tabs.remove(match.id);
+    const tabsPerWindow = {};
+    for (const t of allTabs) tabsPerWindow[t.windowId] = (tabsPerWindow[t.windowId] || 0) + 1;
+    const match = allTabs.find(t => t.url === tabUrl);
+    if (match && !match.pinned && tabsPerWindow[match.windowId] !== 1) await chrome.tabs.remove(match.id);
     await fetchOpenTabs();
 
     playCloseSound();
@@ -1767,12 +1781,12 @@ document.addEventListener('click', async (e) => {
     return;
   }
 
-  // ---- Close ALL open tabs ----
+  // ---- Close ALL open tabs (skips pinned + lone-window tabs) ----
   if (action === 'close-all-open-tabs') {
-    const allUrls = openTabs
-      .filter(t => t.url && !t.url.startsWith('chrome') && !t.url.startsWith('about:'))
+    const closableUrls = openTabs
+      .filter(t => t.url && !t.url.startsWith('chrome') && !t.url.startsWith('about:') && !isProtectedTab(t))
       .map(t => t.url);
-    await closeTabsByUrls(allUrls);
+    await closeTabsByUrls(closableUrls);
     playCloseSound();
 
     document.querySelectorAll('#openTabsMissions .mission-card').forEach(c => {
@@ -1783,7 +1797,10 @@ document.addEventListener('click', async (e) => {
       animateCardOut(c);
     });
 
-    showToast('All tabs closed. Fresh start.');
+    const protectedCount = openTabs.filter(t => isProtectedTab(t)).length;
+    showToast(protectedCount > 0
+      ? `Tabs closed. ${protectedCount} pinned/window tab${protectedCount !== 1 ? 's' : ''} kept.`
+      : 'All tabs closed. Fresh start.');
     return;
   }
 });

--- a/extension/app.js
+++ b/extension/app.js
@@ -1093,6 +1093,21 @@ const CHROME_GROUP_COLORS = {
 };
 
 /**
+ * buildViewToggle(activeView)
+ *
+ * Returns the HTML for the Groups/Domains toggle pill.
+ * Only shown when Chrome tab groups exist (tabGroupsList.length > 0).
+ * activeView: 'group' | 'domain'
+ */
+function buildViewToggle(activeView) {
+  if (tabGroupsList.length === 0) return '';
+  return `<span class="view-toggle">` +
+    `<button class="toggle-pill${activeView === 'group' ? ' active' : ''}" data-action="switch-view" data-view="group">Groups</button>` +
+    `<button class="toggle-pill${activeView === 'domain' ? ' active' : ''}" data-action="switch-view" data-view="domain">Domains</button>` +
+    `</span>&nbsp;&nbsp;`;
+}
+
+/**
  * renderDomainView(realTabs)
  *
  * Groups realTabs by domain and renders domain cards.
@@ -1204,8 +1219,7 @@ async function renderDomainView(realTabs) {
 
   if (domainGroups.length > 0 && openTabsSection) {
     if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-    const toggleHtml = tabGroupsList.length > 0 ? `<span class="view-toggle"><button class="toggle-pill" data-action="switch-view" data-view="group">Groups</button><button class="toggle-pill active" data-action="switch-view" data-view="domain">Domains</button></span>&nbsp;&nbsp;` : '';
-    openTabsSectionCount.innerHTML = `${toggleHtml}${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
+    openTabsSectionCount.innerHTML = `${buildViewToggle('domain')}${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
     openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
     openTabsSection.style.display = 'block';
   } else if (openTabsSection) {
@@ -1258,14 +1272,7 @@ async function renderGroupView(viewMode) {
 
   // Render section header with toggle + count
   if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-  const closeAllId = 'close-all-open-tabs-group';
-  openTabsSectionCount.innerHTML = `
-    <span class="view-toggle">
-      <button class="toggle-pill ${viewMode === 'group' ? 'active' : ''}" data-action="switch-view" data-view="group">Groups</button>
-      <button class="toggle-pill" data-action="switch-view" data-view="domain">Domains</button>
-    </span>
-    &nbsp;&nbsp;${groupCount} group${groupCount !== 1 ? 's' : ''}${ungroupedCount > 0 ? ` · ${ungroupedCount} ungrouped` : ''}
-    &nbsp;&nbsp;<button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
+  openTabsSectionCount.innerHTML = `${buildViewToggle('group')}${groupCount} group${groupCount !== 1 ? 's' : ''}${ungroupedCount > 0 ? ` · ${ungroupedCount} ungrouped` : ''} &nbsp;&nbsp;<button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
 
   // Render group cards + ungrouped section
   let html = '';

--- a/extension/app.js
+++ b/extension/app.js
@@ -1438,16 +1438,25 @@ function renderTabGroupCard(groupInfo, tabs) {
  * NOT a full domain card — just a labeled chip section.
  */
 function renderUngroupedSection(ungroupedTabs) {
-  const { urlCounts, uniqueTabs } = detectDuplicateTabs(ungroupedTabs);
+  const { urlCounts, uniqueTabs, hasDupes, totalExtras, dupeUrls } = detectDuplicateTabs(ungroupedTabs);
 
   const chips = uniqueTabs.map(tab => {
     const label = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
     return buildPageChip(tab, label, urlCounts);
   }).join('');
 
+  let dedupBtn = '';
+  if (hasDupes) {
+    const enc = dupeUrls.map(([url]) => encodeURIComponent(url)).join(',');
+    dedupBtn = `<button class="action-btn" data-action="dedup-keep-one" data-dupe-urls="${enc}">Close ${totalExtras} duplicate${totalExtras !== 1 ? 's' : ''}</button>`;
+  }
+
   return `
-    <div class="ungrouped-section">
-      <div class="ungrouped-label">Not grouped</div>
+    <div class="ungrouped-section${hasDupes ? ' has-dupes' : ''}">
+      <div class="ungrouped-header">
+        <div class="ungrouped-label">Not grouped</div>
+        ${dedupBtn}
+      </div>
       <div class="ungrouped-chips">${chips}</div>
     </div>`;
 }
@@ -1546,6 +1555,7 @@ document.addEventListener('click', async (e) => {
   }
 
   const card = actionEl.closest('.mission-card');
+  const ungroupedSection = actionEl.closest('.ungrouped-section');
 
   // ---- Expand overflow chips ("+N more") ----
   if (action === 'expand-chips') {
@@ -1756,6 +1766,15 @@ document.addEventListener('click', async (e) => {
       });
       card.classList.remove('has-amber-bar');
       card.classList.add('has-neutral-bar');
+    }
+
+    if (ungroupedSection) {
+      ungroupedSection.querySelectorAll('.chip-dupe-badge').forEach(b => {
+        b.style.transition = 'opacity 0.2s';
+        b.style.opacity = '0';
+        setTimeout(() => b.remove(), 200);
+      });
+      ungroupedSection.classList.remove('has-dupes');
     }
 
     showToast('Closed duplicates, kept one copy each');

--- a/extension/index.html
+++ b/extension/index.html
@@ -127,7 +127,7 @@
 
 <!-- Personal config (gitignored) — defines LOCAL_LANDING_PAGE_PATTERNS etc. -->
 <!-- If the file doesn't exist, that's fine — app.js uses sensible defaults. -->
-<script src="config.local.js" onerror="/* no personal config, that's fine */"></script>
+<script src="config.local.js"></script>
 
 <!-- Main dashboard logic — loads last so the DOM is ready -->
 <script src="app.js"></script>

--- a/extension/index.html
+++ b/extension/index.html
@@ -107,7 +107,7 @@
       </div>
     </div>
     <div class="last-refresh">
-      <span style="color: var(--muted); font-size: 11px;"><a href="https://github.com/zarazhangrui/tab-out" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Tab Out</a> by <a href="https://x.com/zarazhangrui" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Zara</a></span>
+      <span style="color: var(--muted); font-size: 11px;"><a href="https://github.com/chess99/tab-out" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Tab Out</a> · fork by <a href="https://github.com/chess99" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Cearl</a> · original by <a href="https://x.com/zarazhangrui" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Zara</a></span>
     </div>
   </footer>
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tab Out",
   "version": "1.0.0",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
-  "permissions": ["tabs", "activeTab", "storage"],
+  "permissions": ["tabs", "activeTab", "storage", "tabGroups"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },
   "action": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
-  "name": "Tab Out",
+  "name": "Tab Out · by Cearl",
   "version": "1.0.0",
-  "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
+  "description": "新标签页变成标签管理中心。按域名分组，支持 Chrome 标签组视图、自定义分组、保护标签等增强功能。",
   "permissions": ["tabs", "activeTab", "storage", "tabGroups"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tab Out · by Cearl",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "新标签页变成标签管理中心。按域名分组，支持 Chrome 标签组视图、自定义分组、保护标签等增强功能。",
   "permissions": ["tabs", "activeTab", "storage", "tabGroups"],
   "chrome_url_overrides": { "newtab": "index.html" },

--- a/extension/style.css
+++ b/extension/style.css
@@ -1156,3 +1156,57 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   opacity: 0.6;
   flex-shrink: 0;
 }
+
+/* ---- View toggle pills ---- */
+.view-toggle {
+  display: inline-flex;
+  gap: 2px;
+  background: var(--bg);
+  border: 1px solid rgba(154, 145, 138, 0.15);
+  border-radius: 20px;
+  padding: 2px;
+}
+
+.toggle-pill {
+  font-size: 11px;
+  font-family: inherit;
+  color: var(--muted);
+  background: transparent;
+  border: none;
+  padding: 3px 10px;
+  border-radius: 16px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  line-height: 1;
+}
+
+.toggle-pill.active {
+  background: var(--ink);
+  color: var(--bg);
+}
+
+.toggle-pill:hover:not(.active) {
+  color: var(--ink);
+}
+
+/* ---- Ungrouped section ---- */
+.ungrouped-section {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(154, 145, 138, 0.1);
+}
+
+.ungrouped-label {
+  font-size: 11px;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 10px;
+  font-weight: 500;
+}
+
+.ungrouped-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}

--- a/extension/style.css
+++ b/extension/style.css
@@ -1207,6 +1207,6 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 
 .ungrouped-chips {
   display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  flex-direction: column;
+  gap: 0;
 }

--- a/extension/style.css
+++ b/extension/style.css
@@ -467,6 +467,44 @@ header {
   padding: 6px 4px;
 }
 
+/* ---- Protected tab chips: pinned & standalone-window ---- */
+
+/* Shared protected icon style */
+.chip-protected-icon {
+  width: 11px;
+  height: 11px;
+  flex-shrink: 0;
+  margin-left: 4px;
+  opacity: 0.55;
+  vertical-align: middle;
+  position: relative;
+  top: -1px;
+}
+
+/* Pinned tab — warm amber tint */
+.page-chip.chip-pinned {
+  background: rgba(200, 113, 58, 0.05);
+  border-bottom-color: rgba(200, 113, 58, 0.15);
+}
+.page-chip.chip-pinned:hover {
+  background: rgba(200, 113, 58, 0.09);
+}
+.chip-pin-icon {
+  color: var(--accent-amber);
+}
+
+/* Standalone-window tab — cool slate-blue tint */
+.page-chip.chip-alone-window {
+  background: rgba(90, 107, 122, 0.05);
+  border-bottom-color: rgba(90, 107, 122, 0.15);
+}
+.page-chip.chip-alone-window:hover {
+  background: rgba(90, 107, 122, 0.09);
+}
+.chip-window-icon {
+  color: var(--accent-slate);
+}
+
 /* mission-meta hidden — see above */
 
 .mission-time {

--- a/extension/style.css
+++ b/extension/style.css
@@ -469,19 +469,35 @@ header {
 
 /* ---- Protected tab chips: pinned & standalone-window ---- */
 
-/* Shared protected icon style */
-.chip-protected-icon {
-  width: 11px;
-  height: 11px;
-  flex-shrink: 0;
-  margin-left: 4px;
-  opacity: 0.55;
-  vertical-align: middle;
+/* Favicon wrapper — gives us a positioning context for the badge overlay */
+.chip-favicon-wrap {
   position: relative;
-  top: -1px;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-/* Pinned tab — warm amber tint */
+/* No-img variant (when favicon fails to load but badge exists) */
+.chip-favicon-wrap--no-img {
+  /* still takes up 16×16 so layout is consistent */
+}
+
+/* Badge icon — pinned at bottom-right corner of the favicon */
+.chip-protected-icon {
+  position: absolute;
+  bottom: -3px;
+  right: -3px;
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  /* white outline so it reads on any favicon */
+  filter: drop-shadow(0 0 1px rgba(255,255,255,0.9)) drop-shadow(0 0 1.5px rgba(255,255,255,0.7));
+}
+
+/* Pinned tab — warm amber tint on row */
 .page-chip.chip-pinned {
   background: rgba(200, 113, 58, 0.05);
   border-bottom-color: rgba(200, 113, 58, 0.15);
@@ -493,7 +509,7 @@ header {
   color: var(--accent-amber);
 }
 
-/* Standalone-window tab — cool slate-blue tint */
+/* Standalone-window tab — cool slate-blue tint on row */
 .page-chip.chip-alone-window {
   background: rgba(90, 107, 122, 0.05);
   border-bottom-color: rgba(90, 107, 122, 0.15);

--- a/extension/style.css
+++ b/extension/style.css
@@ -1250,12 +1250,22 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   border-top: 1px solid rgba(154, 145, 138, 0.1);
 }
 
+.ungrouped-section.has-dupes {
+  border-top: 2px solid var(--accent-amber);
+}
+
+.ungrouped-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
 .ungrouped-label {
   font-size: 11px;
   color: var(--muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 10px;
   font-weight: 500;
 }
 


### PR DESCRIPTION
## Summary

- Add Chrome Tab Groups as the primary view. Chrome tab groups render as cards with color accent bars matching Chrome's group colors. Ungrouped tabs appear in a lightweight "Not grouped" section below.
- "Groups | Domains" toggle pill in the section header. Preference persists in chrome.storage.local. Toggle hidden when no Chrome groups exist.
- Ungroup action per card moves all tabs out of a Chrome tab group in one click.
- Ctrl+Shift+G keyboard shortcut to toggle between views.
- 30-second auto-refresh keeps group state fresh.
- CSP violation fix: removed onerror inline handler from config.local.js script tag.

## Test plan

- No Chrome groups open, domain view renders, toggle hidden
- Chrome groups exist, group view by default, toggle visible
- Toggle switches view, preference persists across reloads
- Close a group card closes all tabs in group
- Ungroup action moves tabs out of Chrome group
- All tabs grouped, "Not grouped" section hidden
- Ctrl+Shift+G toggles view
- Domain view unchanged

## Files

- manifest.json: +"tabGroups" permission (read-only, no install warning)
- app.js: ~400 lines added, new functions for group view, toggle, storage, close-by-id
- style.css: toggle pill and ungrouped section styles
- index.html: CSP fix on config.local.js
