### PR TITLE
feat: add dark mode with theme toggle

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -17,6 +17,48 @@
 
 
 /* ----------------------------------------------------------------
+   THEME — dark mode by default, persisted in chrome.storage.local
+   ---------------------------------------------------------------- */
+
+const THEME_ICONS = {
+  light: `<path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />`,
+  dark: `<path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />`,
+};
+
+function applyTheme(theme) {
+  document.documentElement.setAttribute('data-theme', theme);
+  const icon = document.getElementById('themeIcon');
+  const label = document.getElementById('themeLabel');
+  if (icon) icon.innerHTML = THEME_ICONS[theme === 'dark' ? 'light' : 'dark'];
+  if (label) label.textContent = theme === 'dark' ? 'Light' : 'Dark';
+}
+
+async function loadTheme() {
+  try {
+    const { theme } = await chrome.storage.local.get('theme');
+    applyTheme(theme || 'dark');
+  } catch {
+    applyTheme('dark');
+  }
+}
+
+async function toggleTheme() {
+  const current = document.documentElement.getAttribute('data-theme') || 'dark';
+  const next = current === 'dark' ? 'light' : 'dark';
+  applyTheme(next);
+  try { await chrome.storage.local.set({ theme: next }); } catch {}
+}
+
+// Apply theme immediately (before DOM renders) to prevent flash
+loadTheme();
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('themeToggle');
+  if (btn) btn.addEventListener('click', toggleTheme);
+});
+
+
+/* ----------------------------------------------------------------
    CHROME TABS — Direct API Access
 
    Since this page IS the extension's new tab page, it has full

--- a/extension/index.html
+++ b/extension/index.html
@@ -26,6 +26,12 @@
       <!-- "Friday, April 4, 2026" — written by getDateDisplay() in app.js -->
       <div class="date" id="dateDisplay"></div>
     </div>
+    <button class="theme-toggle" id="themeToggle" title="Switch theme">
+      <svg id="themeIcon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+      </svg>
+      <span id="themeLabel">Light</span>
+    </button>
   </header>
 
   <!-- ================================================================

--- a/extension/style.css
+++ b/extension/style.css
@@ -20,6 +20,27 @@
   --shadow: rgba(26, 22, 19, 0.06);
 }
 
+/* ---- Dark theme — default, toggled via data-theme attribute ---- */
+[data-theme="dark"] {
+  --ink: #e8e2da;
+  --paper: #1a1a1f;
+  --warm-gray: #2e2e35;
+  --muted: #8a8a95;
+  --accent-amber: #e09050;
+  --accent-sage: #6fa87a;
+  --accent-slate: #7a8fa0;
+  --accent-rose: #d06a6a;
+  --status-active: #5aaa66;
+  --status-cooling: #d0a040;
+  --status-abandoned: #d06a6a;
+  --card-bg: #242429;
+  --shadow: rgba(0, 0, 0, 0.25);
+}
+
+[data-theme="dark"] body::before {
+  opacity: 0.015;
+}
+
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
 body {
@@ -1155,4 +1176,31 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   color: var(--muted);
   opacity: 0.6;
   flex-shrink: 0;
+}
+
+/* ---- Theme toggle button ---- */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: 1px solid var(--warm-gray);
+  border-radius: 20px;
+  padding: 6px 14px;
+  cursor: pointer;
+  color: var(--muted);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.theme-toggle:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+.theme-toggle svg {
+  width: 14px;
+  height: 14px;
 }


### PR DESCRIPTION
## Summary

- **Dark mode** as the default theme, with a light/dark toggle button in the header
- Theme preference persists across sessions in `chrome.storage.local`
- All colors remap through existing CSS `var()` tokens — no hardcoded overrides

## Why

The current light-only theme can be harsh on the eyes, especially for users who open new tabs frequently at night. Dark mode is the most-requested visual feature for new tab extensions.

## What's included

- **CSS** (~25 lines): `[data-theme="dark"]` block remaps all 13 design tokens (ink, paper, card-bg, accents, status colors, shadow) plus a reduced paper-texture opacity. Also adds `.theme-toggle` button styles matching the existing `action-btn` design language.
- **HTML**: one `<button>` in the header with a sun/moon SVG icon and a text label ("Light" / "Dark").
- **JS** (~40 lines): `loadTheme()` reads from storage on page load (defaults to `"dark"`), `applyTheme()` sets the `data-theme` attribute and swaps the icon, `toggleTheme()` flips and persists.

## How it works

1. On load, `loadTheme()` reads `chrome.storage.local.theme` — if unset (first install), defaults to `"dark"`
2. Sets `data-theme="dark"` on `<html>`, which activates the CSS variable overrides
3. Click the toggle → flips to `"light"`, saves to storage, swaps the icon to a moon
4. Next new tab → reads the saved preference and applies it before render

## Test plan

- [ ] Fresh install (no prior storage): verify dark mode is the default
- [ ] Toggle to light mode, verify all colors revert to the original warm paper theme
- [ ] Toggle back to dark, verify all cards, badges, banners, and toast use dark palette
- [ ] Close and reopen a new tab — verify theme preference persists
- [ ] Check that the paper texture overlay is subtler in dark mode (opacity reduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)