### PR TITLE
Security + MV3 compat fixes, and a theme switcher

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -173,6 +173,39 @@ async function closeTabOutDupes() {
 
 
 /* ----------------------------------------------------------------
+   THEME SWITCHER
+
+   Four color palettes the user can cycle through (warm / midnight /
+   arctic / forest). The active theme is written to localStorage and
+   re-applied on load by theme-init.js before the body paints, so the
+   page doesn't flash the default palette. This function only has to
+   sync the DOM state and the pressed-button indicator.
+   ---------------------------------------------------------------- */
+const THEMES = ['warm', 'midnight', 'arctic', 'forest'];
+const THEME_STORAGE_KEY = 'tab-out-theme';
+
+function getActiveTheme() {
+  const t = document.documentElement.dataset.theme;
+  return THEMES.includes(t) ? t : 'warm';
+}
+
+function applyTheme(name, { save = false } = {}) {
+  if (!THEMES.includes(name)) return;
+  document.documentElement.dataset.theme = name;
+  if (save) {
+    try { localStorage.setItem(THEME_STORAGE_KEY, name); } catch {}
+  }
+  document.querySelectorAll('.theme-btn[data-theme-name]').forEach(btn => {
+    btn.setAttribute('aria-pressed', btn.dataset.themeName === name ? 'true' : 'false');
+  });
+}
+
+function initThemeSwitcher() {
+  applyTheme(getActiveTheme(), { save: false });
+}
+
+
+/* ----------------------------------------------------------------
    SAVED FOR LATER — chrome.storage.local
 
    Replaces the old server-side SQLite + REST API with Chrome's
@@ -1194,6 +1227,13 @@ document.addEventListener('click', async (e) => {
 
   const action = actionEl.dataset.action;
 
+  // ---- Switch color theme ----
+  if (action === 'set-theme') {
+    const name = actionEl.dataset.themeName;
+    if (name) applyTheme(name, { save: true });
+    return;
+  }
+
   // ---- Close duplicate Tab Out tabs ----
   if (action === 'close-tabout-dupes') {
     await closeTabOutDupes();
@@ -1499,4 +1539,5 @@ document.addEventListener('error', (e) => {
 /* ----------------------------------------------------------------
    INITIALIZE
    ---------------------------------------------------------------- */
+initThemeSwitcher();
 renderDashboard();

--- a/extension/app.js
+++ b/extension/app.js
@@ -26,6 +26,15 @@
 // All open tabs — populated by fetchOpenTabs()
 let openTabs = [];
 
+// Browser-builtin new-tab URLs across Chromium variants (Chrome, Edge,
+// Brave). The extension page URL itself is also treated as Tab Out.
+const BROWSER_NEWTAB_URLS = [
+  'chrome://newtab/',
+  'edge://newtab/',
+  'brave://newtab/',
+  'about:newtab',
+];
+
 /**
  * fetchOpenTabs()
  *
@@ -46,7 +55,7 @@ async function fetchOpenTabs() {
       windowId: t.windowId,
       active:   t.active,
       // Flag Tab Out's own pages so we can detect duplicate new tabs
-      isTabOut: t.url === newtabUrl || t.url === 'chrome://newtab/',
+      isTabOut: t.url === newtabUrl || BROWSER_NEWTAB_URLS.includes(t.url),
     }));
   } catch {
     // chrome.tabs API unavailable (shouldn't happen in an extension page)
@@ -57,39 +66,19 @@ async function fetchOpenTabs() {
 /**
  * closeTabsByUrls(urls)
  *
- * Closes all open tabs whose hostname matches any of the given URLs.
- * After closing, re-fetches the tab list to keep our state accurate.
+ * Closes open tabs that exactly match one of the given URLs.
  *
- * Special case: file:// URLs are matched exactly (they have no hostname).
+ * Previously this matched by hostname, which would also close tabs the
+ * user never saw — e.g. closing a domain card would take down the
+ * corresponding homepage tab that had been split into the Homepages
+ * group. Exact-URL matching keeps the action scoped to what the card
+ * actually shows and still closes every duplicate tab for each URL.
  */
 async function closeTabsByUrls(urls) {
   if (!urls || urls.length === 0) return;
-
-  // Separate file:// URLs (exact match) from regular URLs (hostname match)
-  const targetHostnames = [];
-  const exactUrls = new Set();
-
-  for (const u of urls) {
-    if (u.startsWith('file://')) {
-      exactUrls.add(u);
-    } else {
-      try { targetHostnames.push(new URL(u).hostname); }
-      catch { /* skip unparseable */ }
-    }
-  }
-
+  const urlSet = new Set(urls);
   const allTabs = await chrome.tabs.query({});
-  const toClose = allTabs
-    .filter(tab => {
-      const tabUrl = tab.url || '';
-      if (tabUrl.startsWith('file://') && exactUrls.has(tabUrl)) return true;
-      try {
-        const tabHostname = new URL(tabUrl).hostname;
-        return tabHostname && targetHostnames.includes(tabHostname);
-      } catch { return false; }
-    })
-    .map(tab => tab.id);
-
+  const toClose = allTabs.filter(t => urlSet.has(t.url)).map(t => t.id);
   if (toClose.length > 0) await chrome.tabs.remove(toClose);
   await fetchOpenTabs();
 }
@@ -181,7 +170,7 @@ async function closeTabOutDupes() {
   const allTabs = await chrome.tabs.query({});
   const currentWindow = await chrome.windows.getCurrent();
   const tabOutTabs = allTabs.filter(t =>
-    t.url === newtabUrl || t.url === 'chrome://newtab/'
+    t.url === newtabUrl || BROWSER_NEWTAB_URLS.includes(t.url)
   );
 
   if (tabOutTabs.length <= 1) return;
@@ -515,6 +504,33 @@ function getDateDisplay() {
 
 
 /* ----------------------------------------------------------------
+   HTML ESCAPE — prevents XSS when tab titles/URLs are injected into
+   innerHTML. Tab titles come from arbitrary web pages, so they must
+   be treated as untrusted input.
+   ---------------------------------------------------------------- */
+function escapeHtml(str) {
+  return String(str == null ? '' : str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+// Only allow http/https/file as href targets, so a saved tab with a
+// javascript: URL can't execute script when clicked.
+function isSafeNavUrl(url) {
+  if (!url) return false;
+  try {
+    const scheme = new URL(url).protocol;
+    return scheme === 'http:' || scheme === 'https:' || scheme === 'file:';
+  } catch {
+    return false;
+  }
+}
+
+
+/* ----------------------------------------------------------------
    DOMAIN & TITLE CLEANUP HELPERS
    ---------------------------------------------------------------- */
 
@@ -761,16 +777,16 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
   const hiddenChips = hiddenTabs.map(tab => {
     const label    = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
     const count    = urlCounts[tab.url] || 1;
-    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
+    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${escapeHtml(count)}x)</span>` : '';
     const chipClass = count > 1 ? ' chip-has-dupes' : '';
-    const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
-    const safeTitle = label.replace(/"/g, '&quot;');
+    const safeUrl   = escapeHtml(tab.url || '');
+    const safeTitle = escapeHtml(label);
     let domain = '';
     try { domain = new URL(tab.url).hostname; } catch {}
-    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=16` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}
+      ${faviconUrl ? `<img class="chip-favicon" src="${escapeHtml(faviconUrl)}" alt="">` : ''}
+      <span class="chip-text">${escapeHtml(label)}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
@@ -842,16 +858,16 @@ function renderDomainCard(group) {
       if (parsed.hostname === 'localhost' && parsed.port) label = `${parsed.port} ${label}`;
     } catch {}
     const count    = urlCounts[tab.url];
-    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
+    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${escapeHtml(count)}x)</span>` : '';
     const chipClass = count > 1 ? ' chip-has-dupes' : '';
-    const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
-    const safeTitle = label.replace(/"/g, '&quot;');
+    const safeUrl   = escapeHtml(tab.url || '');
+    const safeTitle = escapeHtml(label);
     let domain = '';
     try { domain = new URL(tab.url).hostname; } catch {}
-    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=16` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}
+      ${faviconUrl ? `<img class="chip-favicon" src="${escapeHtml(faviconUrl)}" alt="">` : ''}
+      <span class="chip-text">${escapeHtml(label)}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
@@ -966,22 +982,25 @@ async function renderDeferredColumn() {
 function renderDeferredItem(item) {
   let domain = '';
   try { domain = new URL(item.url).hostname.replace(/^www\./, ''); } catch {}
-  const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=16`;
+  const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=16` : '';
   const ago = timeAgo(item.savedAt);
+  const safeId    = escapeHtml(item.id);
+  const safeUrl   = escapeHtml(isSafeNavUrl(item.url) ? item.url : '#');
+  const safeTitle = escapeHtml(item.title || item.url || '');
 
   return `
-    <div class="deferred-item" data-deferred-id="${item.id}">
-      <input type="checkbox" class="deferred-checkbox" data-action="check-deferred" data-deferred-id="${item.id}">
+    <div class="deferred-item" data-deferred-id="${safeId}">
+      <input type="checkbox" class="deferred-checkbox" data-action="check-deferred" data-deferred-id="${safeId}">
       <div class="deferred-info">
-        <a href="${item.url}" target="_blank" rel="noopener" class="deferred-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
-          <img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px" onerror="this.style.display='none'">${item.title || item.url}
+        <a href="${safeUrl}" target="_blank" rel="noopener" class="deferred-title" title="${safeTitle}">
+          ${faviconUrl ? `<img src="${escapeHtml(faviconUrl)}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px">` : ''}${safeTitle}
         </a>
         <div class="deferred-meta">
-          <span>${domain}</span>
-          <span>${ago}</span>
+          <span>${escapeHtml(domain)}</span>
+          <span>${escapeHtml(ago)}</span>
         </div>
       </div>
-      <button class="deferred-dismiss" data-action="dismiss-deferred" data-deferred-id="${item.id}" title="Dismiss">
+      <button class="deferred-dismiss" data-action="dismiss-deferred" data-deferred-id="${safeId}" title="Dismiss">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
       </button>
     </div>`;
@@ -994,12 +1013,14 @@ function renderDeferredItem(item) {
  */
 function renderArchiveItem(item) {
   const ago = item.completedAt ? timeAgo(item.completedAt) : timeAgo(item.savedAt);
+  const safeUrl   = escapeHtml(isSafeNavUrl(item.url) ? item.url : '#');
+  const safeTitle = escapeHtml(item.title || item.url || '');
   return `
     <div class="archive-item">
-      <a href="${item.url}" target="_blank" rel="noopener" class="archive-item-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
-        ${item.title || item.url}
+      <a href="${safeUrl}" target="_blank" rel="noopener" class="archive-item-title" title="${safeTitle}">
+        ${safeTitle}
       </a>
-      <span class="archive-item-date">${ago}</span>
+      <span class="archive-item-date">${escapeHtml(ago)}</span>
     </div>`;
 }
 
@@ -1227,10 +1248,11 @@ document.addEventListener('click', async (e) => {
     const tabUrl = actionEl.dataset.tabUrl;
     if (!tabUrl) return;
 
-    // Close the tab in Chrome directly
+    // The chip represents a URL (possibly with an "(Nx)" duplicate badge),
+    // so close every tab with that exact URL, not just the first one found.
     const allTabs = await chrome.tabs.query({});
-    const match   = allTabs.find(t => t.url === tabUrl);
-    if (match) await chrome.tabs.remove(match.id);
+    const ids     = allTabs.filter(t => t.url === tabUrl).map(t => t.id);
+    if (ids.length > 0) await chrome.tabs.remove(ids);
     await fetchOpenTabs();
 
     playCloseSound();
@@ -1280,10 +1302,10 @@ document.addEventListener('click', async (e) => {
       return;
     }
 
-    // Close the tab in Chrome
+    // Close every tab with that exact URL so duplicates also go away.
     const allTabs = await chrome.tabs.query({});
-    const match   = allTabs.find(t => t.url === tabUrl);
-    if (match) await chrome.tabs.remove(match.id);
+    const ids     = allTabs.filter(t => t.url === tabUrl).map(t => t.id);
+    if (ids.length > 0) await chrome.tabs.remove(ids);
     await fetchOpenTabs();
 
     // Animate chip out
@@ -1474,6 +1496,18 @@ document.addEventListener('input', async (e) => {
     console.warn('[tab-out] Archive search failed:', err);
   }
 });
+
+
+/* ----------------------------------------------------------------
+   FAVICON FALLBACK — hide broken favicon images.
+   Inline onerror attributes are blocked by the MV3 default CSP, so we
+   use a single delegated listener in the capture phase (the 'error'
+   event doesn't bubble).
+   ---------------------------------------------------------------- */
+document.addEventListener('error', (e) => {
+  const el = e.target;
+  if (el && el.tagName === 'IMG') el.style.display = 'none';
+}, true);
 
 
 /* ----------------------------------------------------------------

--- a/extension/app.js
+++ b/extension/app.js
@@ -84,21 +84,6 @@ async function closeTabsByUrls(urls) {
 }
 
 /**
- * closeTabsExact(urls)
- *
- * Closes tabs by exact URL match (not hostname). Used for landing pages
- * so closing "Gmail inbox" doesn't also close individual email threads.
- */
-async function closeTabsExact(urls) {
-  if (!urls || urls.length === 0) return;
-  const urlSet = new Set(urls);
-  const allTabs = await chrome.tabs.query({});
-  const toClose = allTabs.filter(t => urlSet.has(t.url)).map(t => t.id);
-  if (toClose.length > 0) await chrome.tabs.remove(toClose);
-  await fetchOpenTabs();
-}
-
-/**
  * focusTab(url)
  *
  * Switches Chrome to the tab with the given URL (exact match first,
@@ -777,7 +762,7 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
   const hiddenChips = hiddenTabs.map(tab => {
     const label    = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
     const count    = urlCounts[tab.url] || 1;
-    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${escapeHtml(count)}x)</span>` : '';
+    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
     const chipClass = count > 1 ? ' chip-has-dupes' : '';
     const safeUrl   = escapeHtml(tab.url || '');
     const safeTitle = escapeHtml(label);
@@ -858,7 +843,7 @@ function renderDomainCard(group) {
       if (parsed.hostname === 'localhost' && parsed.port) label = `${parsed.port} ${label}`;
     } catch {}
     const count    = urlCounts[tab.url];
-    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${escapeHtml(count)}x)</span>` : '';
+    const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
     const chipClass = count > 1 ? ' chip-has-dupes' : '';
     const safeUrl   = escapeHtml(tab.url || '');
     const safeTitle = escapeHtml(label);
@@ -992,7 +977,7 @@ function renderDeferredItem(item) {
     <div class="deferred-item" data-deferred-id="${safeId}">
       <input type="checkbox" class="deferred-checkbox" data-action="check-deferred" data-deferred-id="${safeId}">
       <div class="deferred-info">
-        <a href="${safeUrl}" target="_blank" rel="noopener" class="deferred-title" title="${safeTitle}">
+        <a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="deferred-title" title="${safeTitle}">
           ${faviconUrl ? `<img src="${escapeHtml(faviconUrl)}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px">` : ''}${safeTitle}
         </a>
         <div class="deferred-meta">
@@ -1017,7 +1002,7 @@ function renderArchiveItem(item) {
   const safeTitle = escapeHtml(item.title || item.url || '');
   return `
     <div class="archive-item">
-      <a href="${safeUrl}" target="_blank" rel="noopener" class="archive-item-title" title="${safeTitle}">
+      <a href="${safeUrl}" target="_blank" rel="noopener noreferrer" class="archive-item-title" title="${safeTitle}">
         ${safeTitle}
       </a>
       <span class="archive-item-date">${escapeHtml(ago)}</span>
@@ -1370,16 +1355,8 @@ document.addEventListener('click', async (e) => {
     });
     if (!group) return;
 
-    const urls      = group.tabs.map(t => t.url);
-    // Landing pages and custom groups (whose domain key isn't a real hostname)
-    // must use exact URL matching to avoid closing unrelated tabs
-    const useExact  = group.domain === '__landing-pages__' || !!group.label;
-
-    if (useExact) {
-      await closeTabsExact(urls);
-    } else {
-      await closeTabsByUrls(urls);
-    }
+    const urls = group.tabs.map(t => t.url);
+    await closeTabsByUrls(urls);
 
     if (card) {
       playCloseSound();
@@ -1436,8 +1413,17 @@ document.addEventListener('click', async (e) => {
 
   // ---- Close ALL open tabs ----
   if (action === 'close-all-open-tabs') {
+    // Exclude Tab Out's own new-tab pages (across Chrome/Edge/Brave) and
+    // other internal schemes so we don't close the page the user is on.
     const allUrls = openTabs
-      .filter(t => t.url && !t.url.startsWith('chrome') && !t.url.startsWith('about:'))
+      .filter(t =>
+        t.url &&
+        !t.isTabOut &&
+        !t.url.startsWith('chrome') &&
+        !t.url.startsWith('edge:') &&
+        !t.url.startsWith('brave:') &&
+        !t.url.startsWith('about:')
+      )
       .map(t => t.url);
     await closeTabsByUrls(allUrls);
     playCloseSound();

--- a/extension/index.html
+++ b/extension/index.html
@@ -126,8 +126,9 @@
 </div>
 
 <!-- Personal config (gitignored) — defines LOCAL_LANDING_PAGE_PATTERNS etc. -->
-<!-- If the file doesn't exist, that's fine — app.js uses sensible defaults. -->
-<script src="config.local.js" onerror="/* no personal config, that's fine */"></script>
+<!-- If the file doesn't exist it just 404s; app.js falls back to defaults. -->
+<!-- (Inline onerror attributes are blocked by the MV3 default CSP.) -->
+<script src="config.local.js"></script>
 
 <!-- Main dashboard logic — loads last so the DOM is ready -->
 <script src="app.js"></script>

--- a/extension/index.html
+++ b/extension/index.html
@@ -10,6 +10,9 @@
   <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,300;1,6..72,400&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="style.css">
+
+  <!-- Apply saved theme before body paints (avoids flash of default palette) -->
+  <script src="theme-init.js"></script>
 </head>
 <body>
 <div class="container">
@@ -25,6 +28,27 @@
       <h1 id="greeting"></h1>
       <!-- "Friday, April 4, 2026" — written by getDateDisplay() in app.js -->
       <div class="date" id="dateDisplay"></div>
+    </div>
+    <div class="header-right">
+      <!-- Theme switcher — active state + persistence handled in app.js -->
+      <div class="theme-switcher" id="themeSwitcher" role="radiogroup" aria-label="Theme">
+        <button class="theme-btn" data-action="set-theme" data-theme-name="warm"
+                role="radio" aria-pressed="false" title="Warm paper">
+          <span class="theme-swatch theme-swatch-warm"></span>
+        </button>
+        <button class="theme-btn" data-action="set-theme" data-theme-name="midnight"
+                role="radio" aria-pressed="false" title="Midnight">
+          <span class="theme-swatch theme-swatch-midnight"></span>
+        </button>
+        <button class="theme-btn" data-action="set-theme" data-theme-name="arctic"
+                role="radio" aria-pressed="false" title="Arctic frost">
+          <span class="theme-swatch theme-swatch-arctic"></span>
+        </button>
+        <button class="theme-btn" data-action="set-theme" data-theme-name="forest"
+                role="radio" aria-pressed="false" title="Forest canopy">
+          <span class="theme-swatch theme-swatch-forest"></span>
+        </button>
+      </div>
     </div>
   </header>
 

--- a/extension/style.css
+++ b/extension/style.css
@@ -4,7 +4,8 @@
    also updating the mockup. This is the approved design.
    ============================================================ */
 
-:root {
+:root,
+[data-theme="warm"] {
   --ink: #1a1613;
   --paper: #f8f5f0;
   --warm-gray: #e8e2da;
@@ -19,6 +20,105 @@
   --card-bg: #fffdf9;
   --shadow: rgba(26, 22, 19, 0.06);
 }
+
+/* Midnight — dark cosmic palette */
+[data-theme="midnight"] {
+  --ink: #e6e6fa;
+  --paper: #14101f;
+  --warm-gray: #332849;
+  --muted: #a490c2;
+  --accent-amber: #e0a75a;
+  --accent-sage: #7ab39a;
+  --accent-slate: #8a9cc2;
+  --accent-rose: #d88a8a;
+  --status-active: #5fc98a;
+  --status-cooling: #e0b958;
+  --status-abandoned: #e07a7a;
+  --card-bg: #2b1e3e;
+  --shadow: rgba(0, 0, 0, 0.4);
+}
+
+/* Arctic — cool, crisp steel-blue palette */
+[data-theme="arctic"] {
+  --ink: #1e3a5f;
+  --paper: #eef4fb;
+  --warm-gray: #c6d6e8;
+  --muted: #6b8299;
+  --accent-amber: #d67a2e;
+  --accent-sage: #4a8a94;
+  --accent-slate: #4a6fa5;
+  --accent-rose: #c25a7a;
+  --status-active: #3d8a95;
+  --status-cooling: #c89a45;
+  --status-abandoned: #b35a6a;
+  --card-bg: #ffffff;
+  --shadow: rgba(74, 111, 165, 0.10);
+}
+
+/* Forest — grounded earth tones */
+[data-theme="forest"] {
+  --ink: #1e2f1c;
+  --paper: #f3f1e8;
+  --warm-gray: #d8d4c5;
+  --muted: #7d8471;
+  --accent-amber: #c48a3a;
+  --accent-sage: #2d4a2b;
+  --accent-slate: #556b5c;
+  --accent-rose: #a0553c;
+  --status-active: #4a7c3a;
+  --status-cooling: #b88838;
+  --status-abandoned: #a0553c;
+  --card-bg: #fbfaf4;
+  --shadow: rgba(45, 74, 43, 0.08);
+}
+
+/* ---- Theme switcher (top-right of header) ---- */
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.theme-switcher {
+  display: inline-flex;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 999px;
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray);
+}
+
+.theme-btn {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 1.5px solid transparent;
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.theme-btn:hover { transform: scale(1.08); }
+
+.theme-btn[aria-pressed="true"] {
+  border-color: var(--ink);
+}
+
+.theme-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
+}
+
+.theme-swatch-warm     { background: linear-gradient(135deg, #f8f5f0 50%, #c8713a 50%); }
+.theme-swatch-midnight { background: linear-gradient(135deg, #2b1e3e 50%, #a490c2 50%); }
+.theme-swatch-arctic   { background: linear-gradient(135deg, #eef4fb 50%, #4a6fa5 50%); }
+.theme-swatch-forest   { background: linear-gradient(135deg, #f3f1e8 50%, #2d4a2b 50%); }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
 

--- a/extension/theme-init.js
+++ b/extension/theme-init.js
@@ -1,0 +1,8 @@
+/* Runs synchronously in <head> so the stored theme is applied before
+   the body paints — avoids a flash of the default palette on reload. */
+(function () {
+  try {
+    var t = localStorage.getItem('tab-out-theme');
+    if (t) document.documentElement.dataset.theme = t;
+  } catch (e) { /* localStorage unavailable — fall back to default */ }
+})();


### PR DESCRIPTION
## Summary

Two workstreams that share files, bundled into one PR:

1. **Bug & security fixes** — stored XSS via tab titles, hostname-matching closing unrelated tabs, MV3 CSP violations, Edge/Brave new-tab detection, chip × leaving duplicates open.
2. **Theme switcher** — 4 palettes (Warm paper / Midnight / Arctic frost / Forest canopy) selectable from the top-right of the header; persists across reloads.

All changes are client-side. No build step added.

---

## Part 1 — Bug fixes

### 1.1 Stored XSS via tab titles (high)

`renderDomainCard`, `buildOverflowChips`, `renderDeferredItem`, `renderArchiveItem` all interpolated `tab.title` / `item.title` into `innerHTML` template literals without HTML-escaping. The prior `safeTitle = label.replace(/\"/g, '&quot;')` defended attribute-breakout only, not `innerHTML` injection. Any web page can set `document.title`, so a malicious site could plant `<img src=x onerror=...>` and have it execute on the new-tab page — which has `chrome.tabs` + `chrome.storage` privileges.

**Fix:** a single `escapeHtml()` applied at every interpolation site. Added `isSafeNavUrl()` so a saved `javascript:` URL can't execute when clicked in Saved-for-Later.

### 1.2 Closing a domain card closed unrelated tabs (high)

`closeTabsByUrls` matched by **hostname**. Repro: open `github.com/` (homepage) and `github.com/owner/repo` (deep page) → Tab Out splits them (Homepages group vs github.com card). Clicking \"Close all 1 tab\" on the github.com card also killed the Homepages tab.

**Fix:** exact-URL matching via `Set(urls).has(tab.url)`. Duplicates still close correctly via `filter`. The `file://` special case is no longer needed. The old `closeTabsExact` helper and the `useExact` branch in `close-domain-tabs` were removed as dead code.

### 1.3 Inline event handlers blocked by MV3 CSP (medium)

MV3's default extension CSP forbids inline event attributes. Two spots silently failed:

- `<img … onerror=\"this.style.display='none'\">` on every favicon — broken images didn't hide + one CSP violation per image in console.
- `<script src=\"config.local.js\" onerror=\"...\">` in `index.html` — handler never ran.

**Fix:** removed inline `onerror`. Added one delegated `document.addEventListener('error', …, true)` (capture phase, because `error` doesn't bubble) that hides any failed `<img>`. Left the `<script>` tag to 404 harmlessly when the optional local config is absent.

### 1.4 Edge / Brave new-tab detection (medium)

`isTabOut` and `closeTabOutDupes` only recognized `chrome://newtab/`. On Edge the URL is `edge://newtab/` (also `about:newtab`); on Brave it's `brave://newtab/`. The \"Keep just this one\" duplicate banner never triggered there.

**Fix:** a `BROWSER_NEWTAB_URLS` constant covering the three Chromium variants + `about:newtab`. The `close-all-open-tabs` handler also skips these URLs (and Tab Out's own page via `isTabOut`), so it won't close the user's current new-tab on Edge/Brave.

### 1.5 Closing one chip left duplicates open (low)

Chips show an `(Nx)` badge when a URL is open in multiple tabs, but `close-single-tab` and `defer-single-tab` used `.find()` and only removed the first match.

**Fix:** `.filter()` + batch `chrome.tabs.remove(ids)`.

### 1.6 Housekeeping

- Saved-for-later links: `rel=\"noopener\"` → `rel=\"noopener noreferrer\"` so the `chrome-extension://<id>/...` URL isn't leaked as Referer.
- URL-encoded `domain=` in the Google favicon URL so unusual hostnames don't break it.
- Dropped redundant `escapeHtml(count)` around numeric duplicate counts.

---

## Part 2 — Theme switcher

### Why

The dashboard's palette was a single hand-tuned warm/paper look. Users on dark screens or who just prefer a different mood had no option.

### What

A 4-dot switcher in the header's top-right:

- **Warm paper** (existing default, unchanged)
- **Midnight** — dark purple/cosmic
- **Arctic frost** — cool steel-blue
- **Forest canopy** — grounded earth tones

### How

- **No component CSS changed.** The stylesheet already drove everything off 13 CSS variables (`--ink`, `--paper`, `--accent-*`, `--status-*`, etc.). The original `:root` block moved under `[data-theme=\"warm\"]`; three sibling `[data-theme=\"...\"]` blocks re-map the same 13 variables.
- **No flash of default palette on reload.** A small `theme-init.js` runs synchronously in `<head>`, reads `localStorage`, and sets `document.documentElement.dataset.theme` before the body paints. Kept as a separate file because MV3's default CSP forbids inline `<script>`.
- **Why `localStorage` over `chrome.storage.local`:** the latter is async; reading it from `<head>` would reintroduce the flash. Theme is a single string — localStorage fits exactly.
- `app.js` adds `applyTheme()` + an `aria-pressed` sync, plus a `set-theme` branch in the existing document-level click delegation.

---

## Test plan

- [x] \`node --check\` on \`app.js\` and \`theme-init.js\` passes
- [x] Tab with title \`<img src=x onerror=alert(1)>\` renders as text, no alert fires
- [x] Opening \`github.com\` + \`github.com/owner/repo\` — closing the github.com card leaves the Homepages tab alone
- [x] \`(3x)\` chip × closes all three tabs
- [x] No CSP violations in devtools console
- [x] Duplicate Tab Out banner appears in Edge
- [x] \"Close all N tabs\" in Edge preserves the current \`edge://newtab/\` page
- [x] Theme switcher: clicking each of the 4 dots recolors the page immediately
- [x] Theme persists across reload and across newly opened Tab Out tabs
- [x] On first load with no saved theme, Warm is active and its dot is ringed
- [x] Active theme's dot has a visible ring (aria-pressed indicator)

---

## Deliberately not in this PR (happy to follow up)

- Google Fonts + Google favicon service phone home each new tab, contradicting the \"100% local\" README claim. Fix = bundle a WOFF2 + use the MV3 \`favicon\` permission.
- Footer \`Open tabs\` count includes \`chrome://\` and extension pages, so it's inflated vs the toolbar badge.
- \`chrome.storage.local\` has no quota check in \`saveTabForLater\`.

---

## Commits

1. \`a6d58aa\` — original five fixes (XSS, hostname matching, MV3 CSP, Edge/Brave, chip dedup)
2. \`1d52a08\` — follow-up cleanup (remove dead \`closeTabsExact\`; exclude new-tab URLs from close-all; \`noreferrer\`)
3. \`d315001\` — theme switcher