### PR TITLE
Add dark mode, bookmarks bar mirror, local favicon loading and overall polishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ Once the extension is loaded:
 ## Key Facts
 
 - Tab Out is a pure Chrome extension. No server, no Node.js, no npm.
-- Chrome opens `newtab.html`, which immediately replaces itself with `index.html`; this avoids leaving the main dashboard in Chrome's special New Tab Page state where Chrome M148 can force the native bookmarks bar.
+- Chrome opens `index.html` directly as the new tab override so the address bar stays highlighted after Cmd+T for immediate searching.
 - Saved tabs are stored in `chrome.storage.local` (persists across sessions).
 - 100% local. No data is sent to any external service.
 - To update: `cd tab-out && git pull`, then reload the extension in `chrome://extensions`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,7 @@ Once the extension is loaded:
 ## Key Facts
 
 - Tab Out is a pure Chrome extension. No server, no Node.js, no npm.
+- Chrome opens `newtab.html`, which immediately replaces itself with `index.html`; this avoids leaving the main dashboard in Chrome's special New Tab Page state where Chrome M148 can force the native bookmarks bar.
 - Saved tabs are stored in `chrome.storage.local` (persists across sessions).
 - 100% local. No data is sent to any external service.
 - To update: `cd tab-out && git pull`, then reload the extension in `chrome://extensions`.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ The agent will walk you through it. Takes about 1 minute.
 - **Duplicate detection** flags when you have the same page open twice, with one-click cleanup
 - **Click any tab to jump to it** across windows, no new tab opened
 - **Save for later** bookmark tabs to a checklist before closing them
+- **Bookmarks Bar mirror** keeps your usual shortcuts available on every new tab
+- **Dark mode** follows your system preference by default, with a saved manual toggle
+- **Local favicons** use Chrome's built-in favicon cache instead of a third-party favicon service
 - **Localhost grouping** shows port numbers next to each tab so you can tell your vibe coding projects apart
 - **Expandable groups** show the first 8 tabs with a clickable "+N more"
 - **100% local** your data never leaves your machine
@@ -77,6 +80,8 @@ Everything runs inside the Chrome extension. No external server, no API calls, n
 |------|-----|
 | Extension | Chrome Manifest V3 |
 | Storage | chrome.storage.local |
+| Bookmarks | chrome.bookmarks |
+| Favicons | Chrome extension favicon endpoint |
 | Sound | Web Audio API (synthesized, no files) |
 | Animations | CSS transitions + JS confetti particles |
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Tab Out is a Chrome extension that replaces your new tab page with a dashboard o
 
 No server. No account. No external API calls. Just a Chrome extension.
 
+Tab Out uses a tiny new-tab trampoline that immediately redirects to the dashboard. This avoids leaving the main dashboard in Chrome's special New Tab Page state, where bookmarks-bar visibility became unreliable in Chrome M148.
+
 ---
 
 ## Install with a coding agent
@@ -63,6 +65,8 @@ You'll see Tab Out.
 
 ```
 You open a new tab
+  -> Chrome loads a tiny Tab Out trampoline page
+  -> The trampoline immediately replaces itself with the dashboard
   -> Tab Out shows your open tabs grouped by domain
   -> Homepages (Gmail, X, etc.) get their own group at the top
   -> Click any tab title to jump to it
@@ -79,6 +83,7 @@ Everything runs inside the Chrome extension. No external server, no API calls, n
 | What | How |
 |------|-----|
 | Extension | Chrome Manifest V3 |
+| New tab handoff | `newtab.html` trampoline uses `location.replace()` to load `index.html` |
 | Storage | chrome.storage.local |
 | Bookmarks | chrome.bookmarks |
 | Favicons | Chrome extension favicon endpoint |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tab Out is a Chrome extension that replaces your new tab page with a dashboard o
 
 No server. No account. No external API calls. Just a Chrome extension.
 
-Tab Out uses a tiny new-tab trampoline that immediately redirects to the dashboard. This avoids leaving the main dashboard in Chrome's special New Tab Page state, where bookmarks-bar visibility became unreliable in Chrome M148.
+Tab Out loads the dashboard directly as Chrome's new tab override, so the address bar stays highlighted after Cmd+T and you can start typing a search immediately.
 
 ---
 
@@ -65,8 +65,8 @@ You'll see Tab Out.
 
 ```
 You open a new tab
-  -> Chrome loads a tiny Tab Out trampoline page
-  -> The trampoline immediately replaces itself with the dashboard
+  -> Chrome loads the Tab Out dashboard directly
+  -> The address bar stays highlighted for immediate search
   -> Tab Out shows your open tabs grouped by domain
   -> Homepages (Gmail, X, etc.) get their own group at the top
   -> Click any tab title to jump to it
@@ -83,7 +83,7 @@ Everything runs inside the Chrome extension. No external server, no API calls, n
 | What | How |
 |------|-----|
 | Extension | Chrome Manifest V3 |
-| New tab handoff | `newtab.html` trampoline uses `location.replace()` to load `index.html` |
+| New tab handoff | `index.html` is loaded directly as Chrome's new tab override |
 | Storage | chrome.storage.local |
 | Bookmarks | chrome.bookmarks |
 | Favicons | Chrome extension favicon endpoint |

--- a/extension/app.js
+++ b/extension/app.js
@@ -10,7 +10,8 @@
    2. Groups tabs by domain with a landing pages category
    3. Renders domain cards, banners, and stats
    4. Handles all user actions (close tabs, save for later, focus tab)
-   5. Stores "Saved for Later" tabs in chrome.storage.local (no server)
+   5. Mirrors the Bookmarks Bar folder inside the new-tab page
+   6. Stores "Saved for Later" tabs in chrome.storage.local (no server)
    ================================================================ */
 
 'use strict';
@@ -25,6 +26,291 @@
 
 // All open tabs — populated by fetchOpenTabs()
 let openTabs = [];
+let dashboardRenderTimer = null;
+let dashboardRenderPromise = null;
+let hasRenderedDashboard = false;
+let hasLoadedLocalConfig = false;
+
+// Theme preference is mirrored to localStorage so theme.js can apply it
+// before the stylesheet paints on future new-tab loads.
+const THEME_STORAGE_KEY = 'themePreference';
+const THEME_LOCAL_STORAGE_KEY = 'tabOutTheme';
+
+function normalizeTheme(theme) {
+  return theme === 'dark' || theme === 'light' ? theme : null;
+}
+
+function getSystemTheme() {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function readLocalTheme() {
+  try { return normalizeTheme(localStorage.getItem(THEME_LOCAL_STORAGE_KEY)); }
+  catch { return null; }
+}
+
+function writeLocalTheme(theme) {
+  try { localStorage.setItem(THEME_LOCAL_STORAGE_KEY, theme); }
+  catch { /* localStorage unavailable; chrome.storage still persists */ }
+}
+
+function updateThemeToggle(theme) {
+  const toggle = document.getElementById('themeToggle');
+  const text = document.getElementById('themeToggleText');
+  if (!toggle || !text) return;
+
+  const nextTheme = theme === 'dark' ? 'light' : 'dark';
+  toggle.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+  toggle.setAttribute('aria-label', `Switch to ${nextTheme} mode`);
+  text.textContent = nextTheme === 'dark' ? 'Dark' : 'Light';
+}
+
+function applyTheme(theme) {
+  const resolvedTheme = normalizeTheme(theme) || getSystemTheme();
+  document.documentElement.dataset.theme = resolvedTheme;
+  document.documentElement.style.colorScheme = resolvedTheme;
+  updateThemeToggle(resolvedTheme);
+}
+
+async function initTheme() {
+  let storedTheme = readLocalTheme();
+
+  try {
+    const result = await chrome.storage.local.get(THEME_STORAGE_KEY);
+    storedTheme = normalizeTheme(result[THEME_STORAGE_KEY]) || storedTheme;
+  } catch {
+    // Fall back to the local mirror or system preference.
+  }
+
+  if (storedTheme) writeLocalTheme(storedTheme);
+  applyTheme(storedTheme);
+
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  mediaQuery.addEventListener('change', () => {
+    if (!readLocalTheme()) applyTheme(null);
+  });
+}
+
+async function toggleTheme() {
+  const currentTheme = normalizeTheme(document.documentElement.dataset.theme) || getSystemTheme();
+  const nextTheme = currentTheme === 'dark' ? 'light' : 'dark';
+
+  applyTheme(nextTheme);
+  writeLocalTheme(nextTheme);
+
+  try {
+    await chrome.storage.local.set({ [THEME_STORAGE_KEY]: nextTheme });
+  } catch (err) {
+    console.warn('[tab-out] Could not persist theme preference:', err);
+  }
+
+  showToast(`${nextTheme === 'dark' ? 'Dark' : 'Light'} mode`);
+}
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, ch => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[ch]);
+}
+
+function escapeAttr(value) {
+  return escapeHtml(value);
+}
+
+function faviconUrlForPage(pageUrl, size = 16) {
+  if (!pageUrl || pageUrl.startsWith('javascript:')) return '';
+
+  try {
+    const url = new URL(chrome.runtime.getURL('/_favicon/'));
+    url.searchParams.set('pageUrl', pageUrl);
+    url.searchParams.set('size', String(size));
+    return url.toString();
+  } catch {
+    return '';
+  }
+}
+
+function findBookmarksBarNode(tree) {
+  const root = tree?.[0];
+  const rootChildren = root?.children || [];
+  return rootChildren.find(node => node.id === '1') ||
+    rootChildren.find(node => /bookmarks bar/i.test(node.title || '')) ||
+    rootChildren[0] ||
+    null;
+}
+
+function collectBookmarkLinks(node, limit = 18, links = []) {
+  if (!node || links.length >= limit) return links;
+
+  if (node.url) {
+    if (!node.url.startsWith('javascript:')) links.push(node);
+    return links;
+  }
+
+  for (const child of node.children || []) {
+    collectBookmarkLinks(child, limit, links);
+    if (links.length >= limit) break;
+  }
+
+  return links;
+}
+
+function renderBookmarkLink(bookmark, className = 'bookmark-link') {
+  const title = bookmark.title || bookmark.url || 'Bookmark';
+  const faviconUrl = faviconUrlForPage(bookmark.url, 16);
+
+  return `
+    <a class="${className}" href="${escapeAttr(bookmark.url)}" target="_top" title="${escapeAttr(title)}">
+      ${faviconUrl ? `<img class="bookmark-favicon" src="${faviconUrl}" alt="">` : ''}
+      <span>${escapeHtml(title)}</span>
+    </a>`;
+}
+
+function renderBookmarkItem(node) {
+  if (node.url) return renderBookmarkLink(node);
+
+  const links = collectBookmarkLinks(node);
+  if (links.length === 0) return '';
+
+  return `
+    <details class="bookmark-folder">
+      <summary class="bookmark-link bookmark-folder-summary">
+        <span class="bookmark-folder-icon" aria-hidden="true"></span>
+        <span>${escapeHtml(node.title || 'Folder')}</span>
+      </summary>
+      <div class="bookmark-folder-menu">
+        ${links.map(link => renderBookmarkLink(link, 'bookmark-menu-link')).join('')}
+      </div>
+    </details>`;
+}
+
+function closeBookmarkFolders(exceptFolder = null) {
+  document.querySelectorAll('.bookmark-folder[open]').forEach(folder => {
+    if (folder !== exceptFolder) {
+      folder.open = false;
+      folder.classList.remove('align-left');
+    }
+  });
+}
+
+function positionBookmarkFolderMenu(folder) {
+  if (!folder) return;
+
+  const menu = folder.querySelector('.bookmark-folder-menu');
+  if (!menu) return;
+
+  folder.classList.remove('align-left');
+
+  const folderRect = folder.getBoundingClientRect();
+  const menuWidth = Math.min(320, window.innerWidth - 48);
+  const wouldClipRight = folderRect.left + menuWidth > window.innerWidth - 24;
+  const isRightSide = folderRect.left > window.innerWidth * 0.58;
+
+  if (wouldClipRight || isRightSide) folder.classList.add('align-left');
+}
+
+function handleBookmarkFolderClick(summary) {
+  const folder = summary?.closest('.bookmark-folder');
+  if (!folder) return;
+
+  expandBookmarksBar();
+  closeBookmarkFolders(folder);
+
+  requestAnimationFrame(() => {
+    if (folder.open) positionBookmarkFolderMenu(folder);
+  });
+}
+
+function updateBookmarksOverflow() {
+  const bar = document.getElementById('bookmarksBar');
+  const list = document.getElementById('bookmarksBarList');
+  const toggle = document.getElementById('bookmarksExpandToggle');
+  if (!bar || !list || !toggle || bar.hidden) return;
+
+  const wasExpanded = bar.dataset.expanded === 'true';
+  const previousExpanded = bar.classList.contains('expanded');
+
+  bar.classList.remove('expanded');
+  bar.classList.add('collapsed');
+  const hasOverflow = list.scrollHeight > list.clientHeight + 2;
+
+  bar.classList.toggle('expanded', wasExpanded || previousExpanded);
+  bar.classList.toggle('collapsed', !(wasExpanded || previousExpanded));
+  toggle.hidden = !hasOverflow;
+  toggle.textContent = wasExpanded || previousExpanded ? 'Less' : 'More';
+  toggle.setAttribute('aria-expanded', wasExpanded || previousExpanded ? 'true' : 'false');
+}
+
+async function renderBookmarksBar() {
+  const bar = document.getElementById('bookmarksBar');
+  const list = document.getElementById('bookmarksBarList');
+  if (!bar || !list || !chrome.bookmarks) return;
+
+  try {
+    const tree = await chrome.bookmarks.getTree();
+    const bookmarksBar = findBookmarksBarNode(tree);
+    const items = (bookmarksBar?.children || [])
+      .map(renderBookmarkItem)
+      .filter(Boolean);
+
+    if (items.length === 0) {
+      bar.hidden = true;
+      list.innerHTML = '';
+      return;
+    }
+
+    list.innerHTML = items.join('');
+    bar.hidden = false;
+    const isExpanded = bar.dataset.expanded === 'true';
+    bar.classList.toggle('expanded', isExpanded);
+    bar.classList.toggle('collapsed', !isExpanded);
+    requestAnimationFrame(updateBookmarksOverflow);
+  } catch (err) {
+    console.warn('[tab-out] Could not render bookmarks bar:', err);
+    bar.hidden = true;
+  }
+}
+
+function toggleBookmarksBar() {
+  const bar = document.getElementById('bookmarksBar');
+  if (!bar) return;
+
+  const isExpanded = bar.dataset.expanded === 'true';
+  bar.dataset.expanded = isExpanded ? 'false' : 'true';
+  bar.classList.toggle('expanded', !isExpanded);
+  bar.classList.toggle('collapsed', isExpanded);
+  updateBookmarksOverflow();
+}
+
+function expandBookmarksBar() {
+  const bar = document.getElementById('bookmarksBar');
+  if (!bar) return;
+
+  bar.dataset.expanded = 'true';
+  bar.classList.add('expanded');
+  bar.classList.remove('collapsed');
+  updateBookmarksOverflow();
+}
+
+function loadLocalConfig() {
+  return new Promise(resolve => {
+    const script = document.createElement('script');
+    script.src = 'config.local.js';
+    script.onload = () => { hasLoadedLocalConfig = true; resolve(); };
+    script.onerror = () => resolve();
+    document.head.appendChild(script);
+  });
+}
+
+function setupBrokenImageHandler() {
+  document.addEventListener('error', (e) => {
+    if (e.target instanceof HTMLImageElement) e.target.hidden = true;
+  }, true);
+}
 
 /**
  * fetchOpenTabs()
@@ -45,7 +331,7 @@ async function fetchOpenTabs() {
       title:    t.title,
       windowId: t.windowId,
       active:   t.active,
-      // Flag Tab Out's own pages so we can detect duplicate new tabs
+      // Flag Tab Out's own pages so we can group them like regular tabs
       isTabOut: t.url === newtabUrl || t.url === 'chrome://newtab/',
     }));
   } catch {
@@ -168,35 +454,6 @@ async function closeDuplicateTabs(urls, keepOne = true) {
   if (toClose.length > 0) await chrome.tabs.remove(toClose);
   await fetchOpenTabs();
 }
-
-/**
- * closeTabOutDupes()
- *
- * Closes all duplicate Tab Out new-tab pages except the current one.
- */
-async function closeTabOutDupes() {
-  const extensionId = chrome.runtime.id;
-  const newtabUrl = `chrome-extension://${extensionId}/index.html`;
-
-  const allTabs = await chrome.tabs.query({});
-  const currentWindow = await chrome.windows.getCurrent();
-  const tabOutTabs = allTabs.filter(t =>
-    t.url === newtabUrl || t.url === 'chrome://newtab/'
-  );
-
-  if (tabOutTabs.length <= 1) return;
-
-  // Keep the active Tab Out tab in the CURRENT window — that's the one the
-  // user is looking at right now. Falls back to any active one, then the first.
-  const keep =
-    tabOutTabs.find(t => t.active && t.windowId === currentWindow.id) ||
-    tabOutTabs.find(t => t.active) ||
-    tabOutTabs[0];
-  const toClose = tabOutTabs.filter(t => t.id !== keep.id).map(t => t.id);
-  if (toClose.length > 0) await chrome.tabs.remove(toClose);
-  await fetchOpenTabs();
-}
-
 
 /* ----------------------------------------------------------------
    SAVED FOR LATER — chrome.storage.local
@@ -722,7 +979,7 @@ let domainGroups = [];
 function getRealTabs() {
   return openTabs.filter(t => {
     const url = t.url || '';
-    return (
+    return t.isTabOut || (
       !url.startsWith('chrome://') &&
       !url.startsWith('chrome-extension://') &&
       !url.startsWith('about:') &&
@@ -731,27 +988,6 @@ function getRealTabs() {
     );
   });
 }
-
-/**
- * checkTabOutDupes()
- *
- * Counts how many Tab Out pages are open. If more than 1,
- * shows a banner offering to close the extras.
- */
-function checkTabOutDupes() {
-  const tabOutTabs = openTabs.filter(t => t.isTabOut);
-  const banner  = document.getElementById('tabOutDupeBanner');
-  const countEl = document.getElementById('tabOutDupeCount');
-  if (!banner) return;
-
-  if (tabOutTabs.length > 1) {
-    if (countEl) countEl.textContent = tabOutTabs.length;
-    banner.style.display = 'flex';
-  } else {
-    banner.style.display = 'none';
-  }
-}
-
 
 /* ----------------------------------------------------------------
    OVERFLOW CHIPS ("+N more" expand button in domain cards)
@@ -765,11 +1001,9 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
     const chipClass = count > 1 ? ' chip-has-dupes' : '';
     const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
     const safeTitle = label.replace(/"/g, '&quot;');
-    let domain = '';
-    try { domain = new URL(tab.url).hostname; } catch {}
-    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+    const faviconUrl = faviconUrlForPage(tab.url, 16);
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="">` : ''}
       <span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
@@ -783,7 +1017,7 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
   }).join('');
 
   return `
-    <div class="page-chips-overflow" style="display:none">${hiddenChips}</div>
+    <div class="page-chips-overflow" hidden>${hiddenChips}</div>
     <div class="page-chip page-chip-overflow clickable" data-action="expand-chips">
       <span class="chip-text">+${hiddenTabs.length} more</span>
     </div>`;
@@ -804,6 +1038,7 @@ function renderDomainCard(group) {
   const tabs      = group.tabs || [];
   const tabCount  = tabs.length;
   const isLanding = group.domain === '__landing-pages__';
+  const isTabOutGroup = group.domain === '__tab-out__';
   const stableId  = 'domain-' + group.domain.replace(/[^a-z0-9]/g, '-');
 
   // Count duplicates (exact URL match)
@@ -819,7 +1054,7 @@ function renderDomainCard(group) {
   </span>`;
 
   const dupeBadge = hasDupes
-    ? `<span class="open-tabs-badge" style="color:var(--accent-amber);background:rgba(200,113,58,0.08);">
+    ? `<span class="open-tabs-badge duplicate-badge">
         ${totalExtras} duplicate${totalExtras !== 1 ? 's' : ''}
       </span>`
     : '';
@@ -846,11 +1081,9 @@ function renderDomainCard(group) {
     const chipClass = count > 1 ? ' chip-has-dupes' : '';
     const safeUrl   = (tab.url || '').replace(/"/g, '&quot;');
     const safeTitle = label.replace(/"/g, '&quot;');
-    let domain = '';
-    try { domain = new URL(tab.url).hostname; } catch {}
-    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+    const faviconUrl = faviconUrlForPage(tab.url, 16);
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="">` : ''}
       <span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
@@ -882,7 +1115,7 @@ function renderDomainCard(group) {
       <div class="status-bar"></div>
       <div class="mission-content">
         <div class="mission-top">
-          <span class="mission-name">${isLanding ? 'Homepages' : (group.label || friendlyDomain(group.domain))}</span>
+          <span class="mission-name">${isLanding ? 'Homepages' : isTabOutGroup ? 'Tab Out' : (group.label || friendlyDomain(group.domain))}</span>
           ${tabBadge}
           ${dupeBadge}
         </div>
@@ -924,36 +1157,36 @@ async function renderDeferredColumn() {
 
     // Hide the entire column if there's nothing to show
     if (active.length === 0 && archived.length === 0) {
-      column.style.display = 'none';
+      column.hidden = true;
       return;
     }
 
-    column.style.display = 'block';
+    column.hidden = false;
 
     // Render active checklist items
     if (active.length > 0) {
       countEl.textContent = `${active.length} item${active.length !== 1 ? 's' : ''}`;
       list.innerHTML = active.map(item => renderDeferredItem(item)).join('');
-      list.style.display = 'block';
-      empty.style.display = 'none';
+      list.hidden = false;
+      empty.hidden = true;
     } else {
-      list.style.display = 'none';
+      list.hidden = true;
       countEl.textContent = '';
-      empty.style.display = 'block';
+      empty.hidden = false;
     }
 
     // Render archive section
     if (archived.length > 0) {
       archiveCountEl.textContent = `(${archived.length})`;
       archiveList.innerHTML = archived.map(item => renderArchiveItem(item)).join('');
-      archiveEl.style.display = 'block';
+      archiveEl.hidden = false;
     } else {
-      archiveEl.style.display = 'none';
+      archiveEl.hidden = true;
     }
 
   } catch (err) {
     console.warn('[tab-out] Could not load saved tabs:', err);
-    column.style.display = 'none';
+    column.hidden = true;
   }
 }
 
@@ -966,7 +1199,7 @@ async function renderDeferredColumn() {
 function renderDeferredItem(item) {
   let domain = '';
   try { domain = new URL(item.url).hostname.replace(/^www\./, ''); } catch {}
-  const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=16`;
+  const faviconUrl = faviconUrlForPage(item.url, 16);
   const ago = timeAgo(item.savedAt);
 
   return `
@@ -974,7 +1207,7 @@ function renderDeferredItem(item) {
       <input type="checkbox" class="deferred-checkbox" data-action="check-deferred" data-deferred-id="${item.id}">
       <div class="deferred-info">
         <a href="${item.url}" target="_blank" rel="noopener" class="deferred-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
-          <img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px" onerror="this.style.display='none'">${item.title || item.url}
+          ${faviconUrl ? `<img class="deferred-favicon" src="${faviconUrl}" alt="">` : ''}${item.title || item.url}
         </a>
         <div class="deferred-meta">
           <span>${domain}</span>
@@ -1016,15 +1249,20 @@ function renderArchiveItem(item) {
  * 2. Fetches open tabs via chrome.tabs.query()
  * 3. Groups tabs by domain (with landing pages pulled out to their own group)
  * 4. Renders domain cards
- * 5. Updates footer stats
+ * 5. Renders the bookmarks bar mirror
  * 6. Renders the "Saved for Later" checklist
  */
 async function renderStaticDashboard() {
+  document.body.classList.toggle('has-rendered-dashboard', hasRenderedDashboard);
+
   // --- Header ---
   const greetingEl = document.getElementById('greeting');
   const dateEl     = document.getElementById('dateDisplay');
   if (greetingEl) greetingEl.textContent = getGreeting();
   if (dateEl)     dateEl.textContent     = getDateDisplay();
+
+  // --- Bookmarks bar mirror ---
+  await renderBookmarksBar();
 
   // --- Fetch tabs ---
   await fetchOpenTabs();
@@ -1089,6 +1327,12 @@ async function renderStaticDashboard() {
 
   for (const tab of realTabs) {
     try {
+      if (tab.isTabOut) {
+        if (!groupMap['__tab-out__']) groupMap['__tab-out__'] = { domain: '__tab-out__', tabs: [] };
+        groupMap['__tab-out__'].tabs.push(tab);
+        continue;
+      }
+
       if (isLandingPage(tab.url)) {
         landingTabs.push(tab);
         continue;
@@ -1135,6 +1379,10 @@ async function renderStaticDashboard() {
     const bIsLanding = b.domain === '__landing-pages__';
     if (aIsLanding !== bIsLanding) return aIsLanding ? -1 : 1;
 
+    const aIsTabOut = a.domain === '__tab-out__';
+    const bIsTabOut = b.domain === '__tab-out__';
+    if (aIsTabOut !== bIsTabOut) return aIsTabOut ? -1 : 1;
+
     const aIsPriority = isLandingDomain(a.domain);
     const bIsPriority = isLandingDomain(b.domain);
     if (aIsPriority !== bIsPriority) return aIsPriority ? -1 : 1;
@@ -1150,26 +1398,32 @@ async function renderStaticDashboard() {
 
   if (domainGroups.length > 0 && openTabsSection) {
     if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-    openTabsSectionCount.innerHTML = `${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&middot;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
+    openTabsSectionCount.innerHTML = `${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&middot;&nbsp; <button class="action-btn close-tabs close-all-open-tabs" data-action="close-all-open-tabs">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
     openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
-    openTabsSection.style.display = 'block';
+    openTabsSection.hidden = false;
   } else if (openTabsSection) {
-    openTabsSection.style.display = 'none';
+    openTabsSection.hidden = true;
   }
-
-  // --- Footer stats ---
-  const statTabs = document.getElementById('statTabs');
-  if (statTabs) statTabs.textContent = openTabs.length;
-
-  // --- Check for duplicate Tab Out tabs ---
-  checkTabOutDupes();
 
   // --- Render "Saved for Later" column ---
   await renderDeferredColumn();
+
+  hasRenderedDashboard = true;
+  document.body.classList.add('has-rendered-dashboard');
 }
 
 async function renderDashboard() {
   await renderStaticDashboard();
+}
+
+function scheduleDashboardRender() {
+  clearTimeout(dashboardRenderTimer);
+  dashboardRenderTimer = setTimeout(() => {
+    dashboardRenderPromise = (dashboardRenderPromise || Promise.resolve())
+      .then(renderDashboard)
+      .catch(err => console.warn('[tab-out] Dashboard refresh failed:', err))
+      .finally(() => { dashboardRenderPromise = null; });
+  }, 100);
 }
 
 
@@ -1182,23 +1436,28 @@ async function renderDashboard() {
    ---------------------------------------------------------------- */
 
 document.addEventListener('click', async (e) => {
+  const bookmarkSummary = e.target.closest('.bookmark-folder-summary');
+  if (bookmarkSummary) {
+    handleBookmarkFolderClick(bookmarkSummary);
+  } else if (!e.target.closest('.bookmark-folder')) {
+    closeBookmarkFolders();
+  }
+
   // Walk up the DOM to find the nearest element with data-action
   const actionEl = e.target.closest('[data-action]');
   if (!actionEl) return;
 
   const action = actionEl.dataset.action;
 
-  // ---- Close duplicate Tab Out tabs ----
-  if (action === 'close-tabout-dupes') {
-    await closeTabOutDupes();
-    playCloseSound();
-    const banner = document.getElementById('tabOutDupeBanner');
-    if (banner) {
-      banner.style.transition = 'opacity 0.4s';
-      banner.style.opacity = '0';
-      setTimeout(() => { banner.style.display = 'none'; banner.style.opacity = '1'; }, 400);
-    }
-    showToast('Closed extra Tab Out tabs');
+  // ---- Toggle dark/light mode ----
+  if (action === 'toggle-theme') {
+    await toggleTheme();
+    return;
+  }
+
+  // ---- Expand/collapse bookmarks bar mirror ----
+  if (action === 'toggle-bookmarks') {
+    toggleBookmarksBar();
     return;
   }
 
@@ -1208,7 +1467,7 @@ document.addEventListener('click', async (e) => {
   if (action === 'expand-chips') {
     const overflowContainer = actionEl.parentElement.querySelector('.page-chips-overflow');
     if (overflowContainer) {
-      overflowContainer.style.display = 'contents';
+      overflowContainer.hidden = false;
       actionEl.remove();
     }
     return;
@@ -1255,10 +1514,6 @@ document.addEventListener('click', async (e) => {
         });
       }, 200);
     }
-
-    // Update footer
-    const statTabs = document.getElementById('statTabs');
-    if (statTabs) statTabs.textContent = openTabs.length;
 
     showToast('Tab closed');
     return;
@@ -1351,7 +1606,7 @@ document.addEventListener('click', async (e) => {
     const urls      = group.tabs.map(t => t.url);
     // Landing pages and custom groups (whose domain key isn't a real hostname)
     // must use exact URL matching to avoid closing unrelated tabs
-    const useExact  = group.domain === '__landing-pages__' || !!group.label;
+    const useExact  = group.domain === '__landing-pages__' || group.domain === '__tab-out__' || !!group.label;
 
     if (useExact) {
       await closeTabsExact(urls);
@@ -1368,11 +1623,9 @@ document.addEventListener('click', async (e) => {
     const idx = domainGroups.indexOf(group);
     if (idx !== -1) domainGroups.splice(idx, 1);
 
-    const groupLabel = group.domain === '__landing-pages__' ? 'Homepages' : (group.label || friendlyDomain(group.domain));
+    const groupLabel = group.domain === '__landing-pages__' ? 'Homepages' : group.domain === '__tab-out__' ? 'Tab Out' : (group.label || friendlyDomain(group.domain));
     showToast(`Closed ${urls.length} tab${urls.length !== 1 ? 's' : ''} from ${groupLabel}`);
 
-    const statTabs = document.getElementById('statTabs');
-    if (statTabs) statTabs.textContent = openTabs.length;
     return;
   }
 
@@ -1441,7 +1694,7 @@ document.addEventListener('click', (e) => {
   toggle.classList.toggle('open');
   const body = document.getElementById('archiveBody');
   if (body) {
-    body.style.display = body.style.display === 'none' ? 'block' : 'none';
+    body.hidden = !body.hidden;
   }
 });
 
@@ -1469,7 +1722,7 @@ document.addEventListener('input', async (e) => {
     );
 
     archiveList.innerHTML = results.map(item => renderArchiveItem(item)).join('')
-      || '<div style="font-size:12px;color:var(--muted);padding:8px 0">No results</div>';
+      || '<div class="archive-no-results">No results</div>';
   } catch (err) {
     console.warn('[tab-out] Archive search failed:', err);
   }
@@ -1479,4 +1732,26 @@ document.addEventListener('input', async (e) => {
 /* ----------------------------------------------------------------
    INITIALIZE
    ---------------------------------------------------------------- */
-renderDashboard();
+initTheme();
+setupBrokenImageHandler();
+loadLocalConfig().finally(renderDashboard);
+window.addEventListener('resize', () => {
+  updateBookmarksOverflow();
+  closeBookmarkFolders();
+});
+
+chrome.tabs.onCreated.addListener(scheduleDashboardRender);
+chrome.tabs.onRemoved.addListener(scheduleDashboardRender);
+chrome.tabs.onUpdated.addListener(scheduleDashboardRender);
+chrome.tabs.onMoved.addListener(scheduleDashboardRender);
+chrome.tabs.onAttached.addListener(scheduleDashboardRender);
+chrome.tabs.onDetached.addListener(scheduleDashboardRender);
+chrome.tabs.onReplaced.addListener(scheduleDashboardRender);
+chrome.windows.onFocusChanged.addListener(scheduleDashboardRender);
+
+chrome.bookmarks.onCreated.addListener(scheduleDashboardRender);
+chrome.bookmarks.onRemoved.addListener(scheduleDashboardRender);
+chrome.bookmarks.onChanged.addListener(scheduleDashboardRender);
+chrome.bookmarks.onMoved.addListener(scheduleDashboardRender);
+chrome.bookmarks.onChildrenReordered.addListener(scheduleDashboardRender);
+chrome.bookmarks.onImportEnded.addListener(scheduleDashboardRender);

--- a/extension/app.js
+++ b/extension/app.js
@@ -20,7 +20,7 @@
 /* ----------------------------------------------------------------
    CHROME TABS — Direct API Access
 
-   Since this page IS the extension's new tab page, it has full
+   Since this page is loaded directly from the extension, it has full
    access to chrome.tabs and chrome.storage. No middleman needed.
    ---------------------------------------------------------------- */
 
@@ -30,6 +30,7 @@ let dashboardRenderTimer = null;
 let dashboardRenderPromise = null;
 let hasRenderedDashboard = false;
 let hasLoadedLocalConfig = false;
+let lastPointerActivityAt = 0;
 
 // Theme preference is mirrored to localStorage so theme.js can apply it
 // before the stylesheet paints on future new-tab loads.
@@ -321,7 +322,7 @@ function setupBrokenImageHandler() {
 async function fetchOpenTabs() {
   try {
     const extensionId = chrome.runtime.id;
-    // The new URL for this page is now index.html (not newtab.html)
+    // newtab.html is only a trampoline; the dashboard lives at index.html.
     const newtabUrl = `chrome-extension://${extensionId}/index.html`;
 
     const tabs = await chrome.tabs.query({});
@@ -1416,14 +1417,21 @@ async function renderDashboard() {
   await renderStaticDashboard();
 }
 
-function scheduleDashboardRender() {
+function scheduleDashboardRender(delay = 100) {
   clearTimeout(dashboardRenderTimer);
+
   dashboardRenderTimer = setTimeout(() => {
+    const pointerQuietFor = Date.now() - lastPointerActivityAt;
+    if (pointerQuietFor < 250) {
+      scheduleDashboardRender(250 - pointerQuietFor);
+      return;
+    }
+
     dashboardRenderPromise = (dashboardRenderPromise || Promise.resolve())
       .then(renderDashboard)
       .catch(err => console.warn('[tab-out] Dashboard refresh failed:', err))
       .finally(() => { dashboardRenderPromise = null; });
-  }, 100);
+  }, delay);
 }
 
 
@@ -1734,24 +1742,31 @@ document.addEventListener('input', async (e) => {
    ---------------------------------------------------------------- */
 initTheme();
 setupBrokenImageHandler();
-loadLocalConfig().finally(renderDashboard);
+document.addEventListener('pointerdown', () => { lastPointerActivityAt = Date.now(); }, true);
+document.addEventListener('pointerup', () => { lastPointerActivityAt = Date.now(); }, true);
+document.addEventListener('pointercancel', () => { lastPointerActivityAt = Date.now(); }, true);
+
+dashboardRenderPromise = loadLocalConfig()
+  .then(renderDashboard)
+  .catch(err => console.warn('[tab-out] Initial dashboard render failed:', err))
+  .finally(() => { dashboardRenderPromise = null; });
 window.addEventListener('resize', () => {
   updateBookmarksOverflow();
   closeBookmarkFolders();
 });
 
-chrome.tabs.onCreated.addListener(scheduleDashboardRender);
-chrome.tabs.onRemoved.addListener(scheduleDashboardRender);
-chrome.tabs.onUpdated.addListener(scheduleDashboardRender);
-chrome.tabs.onMoved.addListener(scheduleDashboardRender);
-chrome.tabs.onAttached.addListener(scheduleDashboardRender);
-chrome.tabs.onDetached.addListener(scheduleDashboardRender);
-chrome.tabs.onReplaced.addListener(scheduleDashboardRender);
-chrome.windows.onFocusChanged.addListener(scheduleDashboardRender);
+chrome.tabs.onCreated.addListener(() => scheduleDashboardRender());
+chrome.tabs.onRemoved.addListener(() => scheduleDashboardRender());
+chrome.tabs.onUpdated.addListener(() => scheduleDashboardRender());
+chrome.tabs.onMoved.addListener(() => scheduleDashboardRender());
+chrome.tabs.onAttached.addListener(() => scheduleDashboardRender());
+chrome.tabs.onDetached.addListener(() => scheduleDashboardRender());
+chrome.tabs.onReplaced.addListener(() => scheduleDashboardRender());
+chrome.windows.onFocusChanged.addListener(() => scheduleDashboardRender());
 
-chrome.bookmarks.onCreated.addListener(scheduleDashboardRender);
-chrome.bookmarks.onRemoved.addListener(scheduleDashboardRender);
-chrome.bookmarks.onChanged.addListener(scheduleDashboardRender);
-chrome.bookmarks.onMoved.addListener(scheduleDashboardRender);
-chrome.bookmarks.onChildrenReordered.addListener(scheduleDashboardRender);
-chrome.bookmarks.onImportEnded.addListener(scheduleDashboardRender);
+chrome.bookmarks.onCreated.addListener(() => scheduleDashboardRender());
+chrome.bookmarks.onRemoved.addListener(() => scheduleDashboardRender());
+chrome.bookmarks.onChanged.addListener(() => scheduleDashboardRender());
+chrome.bookmarks.onMoved.addListener(() => scheduleDashboardRender());
+chrome.bookmarks.onChildrenReordered.addListener(() => scheduleDashboardRender());
+chrome.bookmarks.onImportEnded.addListener(() => scheduleDashboardRender());

--- a/extension/app.js
+++ b/extension/app.js
@@ -322,7 +322,7 @@ function setupBrokenImageHandler() {
 async function fetchOpenTabs() {
   try {
     const extensionId = chrome.runtime.id;
-    // newtab.html is only a trampoline; the dashboard lives at index.html.
+    // The dashboard is the direct new-tab override so Chrome keeps the omnibox focused.
     const newtabUrl = `chrome-extension://${extensionId}/index.html`;
 
     const tabs = await chrome.tabs.query({});

--- a/extension/index.html
+++ b/extension/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,300;1,6..72,400&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 
+  <script src="theme.js"></script>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -26,25 +27,24 @@
       <!-- "Friday, April 4, 2026" — written by getDateDisplay() in app.js -->
       <div class="date" id="dateDisplay"></div>
     </div>
+    <div class="header-right">
+      <button class="theme-toggle" id="themeToggle" data-action="toggle-theme" type="button" aria-pressed="false" aria-label="Switch to dark mode">
+        <span class="theme-toggle-icon" id="themeToggleIcon" aria-hidden="true"></span>
+        <span id="themeToggleText">Dark</span>
+      </button>
+    </div>
   </header>
 
   <!-- ================================================================
-       TAB OUT DUPES BANNER — appears when you have extra Tab Out tabs open
-       Hidden by default; app.js shows it when dupeTabOutCount > 1
+       BOOKMARKS BAR — mirrors Chrome's Bookmarks Bar folder because
+       native browser chrome is not shown on extension new-tab pages
        ================================================================ -->
-  <div class="tab-cleanup-banner" id="tabOutDupeBanner" style="display:none">
-    <div class="tab-cleanup-left">
-      <div class="tab-cleanup-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75" />
-        </svg>
-      </div>
-      <div class="tab-cleanup-text">
-        You have <strong id="tabOutDupeCount"></strong> Tab Out tabs open. Keep just this one?
-      </div>
-    </div>
-    <button class="tab-cleanup-btn" data-action="close-tabout-dupes">Close extras</button>
-  </div>
+  <nav class="bookmarks-bar" id="bookmarksBar" aria-label="Bookmarks bar" hidden>
+    <div class="bookmarks-bar-scroll" id="bookmarksBarList"></div>
+    <button class="bookmarks-expand-toggle" id="bookmarksExpandToggle" data-action="toggle-bookmarks" type="button" hidden aria-expanded="false">
+      More
+    </button>
+  </nav>
 
   <!-- ================================================================
        MAIN CONTENT AREA — two-column layout
@@ -55,7 +55,7 @@
   <div class="dashboard-columns" id="dashboardColumns">
 
     <!-- LEFT COLUMN: Open tabs -->
-    <div class="active-section" id="openTabsSection" style="display:none">
+    <div class="active-section" id="openTabsSection" hidden>
       <div class="section-header">
         <h2 id="openTabsSectionTitle">Right now</h2>
         <div class="section-line"></div>
@@ -65,7 +65,7 @@
     </div>
 
     <!-- RIGHT COLUMN: Saved for Later checklist -->
-    <div class="deferred-column" id="deferredColumn" style="display:none">
+    <div class="deferred-column" id="deferredColumn" hidden>
       <div class="section-header">
         <h2>Saved for later</h2>
         <div class="section-line"></div>
@@ -76,18 +76,18 @@
       <div class="deferred-list" id="deferredList"></div>
 
       <!-- Empty state — shown when no active deferred tabs -->
-      <div class="deferred-empty" id="deferredEmpty" style="display:none">
+      <div class="deferred-empty" id="deferredEmpty" hidden>
         Nothing saved. Living in the moment.
       </div>
 
       <!-- Archive section — collapsed by default -->
-      <div class="deferred-archive" id="deferredArchive" style="display:none">
+      <div class="deferred-archive" id="deferredArchive" hidden>
         <button class="archive-toggle" id="archiveToggle">
           <svg class="archive-chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
           Archive
           <span class="archive-count" id="archiveCount"></span>
         </button>
-        <div class="archive-body" id="archiveBody" style="display:none">
+        <div class="archive-body" id="archiveBody" hidden>
           <input type="text" class="archive-search" id="archiveSearch" placeholder="Search archived tabs...">
           <div class="archive-list" id="archiveList"></div>
         </div>
@@ -95,21 +95,6 @@
     </div>
 
   </div><!-- end .dashboard-columns -->
-
-  <!-- ================================================================
-       FOOTER — global stats + refresh control
-       ================================================================ -->
-  <footer>
-    <div class="footer-stats">
-      <div class="stat">
-        <div class="stat-num" id="statTabs">—</div>
-        <div class="stat-label">Open tabs</div>
-      </div>
-    </div>
-    <div class="last-refresh">
-      <span style="color: var(--muted); font-size: 11px;"><a href="https://github.com/zarazhangrui/tab-out" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Tab Out</a> by <a href="https://x.com/zarazhangrui" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Zara</a></span>
-    </div>
-  </footer>
 
 </div><!-- end .container -->
 
@@ -124,10 +109,6 @@
   </svg>
   <span id="toastText"></span>
 </div>
-
-<!-- Personal config (gitignored) — defines LOCAL_LANDING_PAGE_PATTERNS etc. -->
-<!-- If the file doesn't exist, that's fine — app.js uses sensible defaults. -->
-<script src="config.local.js" onerror="/* no personal config, that's fine */"></script>
 
 <!-- Main dashboard logic — loads last so the DOM is ready -->
 <script src="app.js"></script>

--- a/extension/index.html
+++ b/extension/index.html
@@ -36,8 +36,8 @@
   </header>
 
   <!-- ================================================================
-       BOOKMARKS BAR — mirrors Chrome's Bookmarks Bar folder because
-       native browser chrome is not shown on extension new-tab pages
+       BOOKMARKS BAR — mirrors Chrome's Bookmarks Bar folder inside
+       the page, independent of Chrome's native browser chrome
        ================================================================ -->
   <nav class="bookmarks-bar" id="bookmarksBar" aria-label="Bookmarks bar" hidden>
     <div class="bookmarks-bar-scroll" id="bookmarksBarList"></div>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tab Out",
   "version": "1.0.0",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
-  "permissions": ["tabs", "activeTab", "storage"],
+  "permissions": ["tabs", "activeTab", "storage", "bookmarks", "favicon"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },
   "action": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": 3,
   "name": "Tab Out",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
   "permissions": ["tabs", "activeTab", "storage", "bookmarks", "favicon"],
-  "chrome_url_overrides": { "newtab": "newtab.html" },
+  "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },
   "action": {
     "default_title": "Tab Out",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,10 +1,10 @@
 {
   "manifest_version": 3,
   "name": "Tab Out",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
   "permissions": ["tabs", "activeTab", "storage", "bookmarks", "favicon"],
-  "chrome_url_overrides": { "newtab": "index.html" },
+  "chrome_url_overrides": { "newtab": "newtab.html" },
   "background": { "service_worker": "background.js" },
   "action": {
     "default_title": "Tab Out",

--- a/extension/newtab.html
+++ b/extension/newtab.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tab Out</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: #f8f5f0;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { background: #111311; }
+    }
+  </style>
+</head>
+<body>
+  <script src="newtab.js"></script>
+</body>
+</html>

--- a/extension/newtab.js
+++ b/extension/newtab.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// Chrome M148 can force the native bookmarks bar onto extension-provided New
+// Tab pages. Keep Chrome's new-tab hook on this tiny trampoline, then replace
+// it with the real dashboard so Tab Out runs as a normal extension page.
+location.replace(chrome.runtime.getURL('index.html'));

--- a/extension/newtab.js
+++ b/extension/newtab.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// Chrome M148 can force the native bookmarks bar onto extension-provided New
-// Tab pages. Keep Chrome's new-tab hook on this tiny trampoline, then replace
-// it with the real dashboard so Tab Out runs as a normal extension page.
+// Legacy fallback for already-loaded unpacked installs until Chrome reloads
+// the manifest. New installs load index.html directly as the new-tab override.
 location.replace(chrome.runtime.getURL('index.html'));

--- a/extension/style.css
+++ b/extension/style.css
@@ -18,6 +18,28 @@
   --status-abandoned: #b35a5a;
   --card-bg: #fffdf9;
   --shadow: rgba(26, 22, 19, 0.06);
+  --control-bg: #fffdf9;
+  --control-hover: rgba(154, 145, 138, 0.1);
+  color-scheme: light;
+}
+
+:root[data-theme="dark"] {
+  --ink: #f1ebe2;
+  --paper: #111311;
+  --warm-gray: #34322d;
+  --muted: #aaa29a;
+  --accent-amber: #e09a62;
+  --accent-sage: #8ab094;
+  --accent-slate: #9aacba;
+  --accent-rose: #df8d8d;
+  --status-active: #7fbe8d;
+  --status-cooling: #d5a84c;
+  --status-abandoned: #df8d8d;
+  --card-bg: #191b18;
+  --shadow: rgba(0, 0, 0, 0.28);
+  --control-bg: #20221e;
+  --control-hover: rgba(241, 235, 226, 0.08);
+  color-scheme: dark;
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -40,6 +62,10 @@ body::before {
   z-index: 0;
 }
 
+:root[data-theme="dark"] body::before {
+  opacity: 0.45;
+}
+
 .container {
   position: relative;
   z-index: 1;
@@ -59,6 +85,7 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  gap: 24px;
   margin-bottom: 48px;
   padding-bottom: 24px;
   border-bottom: 1px solid var(--warm-gray);
@@ -81,68 +108,231 @@ header {
   text-transform: uppercase;
 }
 
-/* ---- Tab cleanup banner ---- */
-.tab-cleanup-banner {
-  background: linear-gradient(135deg, rgba(200, 113, 58, 0.04), rgba(200, 113, 58, 0.09));
-  border: 1px solid rgba(200, 113, 58, 0.18);
-  border-radius: 8px;
-  padding: 16px 24px;
+.header-right {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  margin-bottom: 16px;
 }
 
-.tab-cleanup-left {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-}
-
-.tab-cleanup-icon {
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background: rgba(200, 113, 58, 0.1);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-
-.tab-cleanup-icon svg {
-  width: 18px;
-  height: 18px;
-  color: var(--accent-amber);
-}
-
-.tab-cleanup-text {
-  font-size: 13px;
-  color: var(--ink);
-  line-height: 1.5;
-}
-
-.tab-cleanup-text strong {
-  font-weight: 600;
-}
-
-.tab-cleanup-btn {
+.theme-toggle {
   font-family: 'DM Sans', sans-serif;
   font-size: 12px;
   font-weight: 600;
-  padding: 8px 20px;
+  color: var(--muted);
+  background: var(--control-bg);
+  border: 1px solid var(--warm-gray);
   border-radius: 6px;
-  border: none;
-  background: var(--accent-amber);
-  color: white;
+  padding: 7px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   cursor: pointer;
-  transition: all 0.2s;
-  white-space: nowrap;
+  transition: background 0.2s, border-color 0.2s, color 0.2s, transform 0.2s;
 }
 
-.tab-cleanup-btn:hover {
-  opacity: 0.85;
+.theme-toggle:hover {
+  color: var(--ink);
+  border-color: var(--muted);
+  background: var(--control-hover);
   transform: translateY(-1px);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent-amber);
+  outline-offset: 3px;
+}
+
+.theme-toggle-icon {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 1.5px solid currentColor;
+  position: relative;
+  flex-shrink: 0;
+}
+
+.theme-toggle-icon::after {
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.55;
+}
+
+:root[data-theme="dark"] .theme-toggle-icon::after {
+  inset: -1px -3px 1px 4px;
+  background: var(--control-bg);
+  opacity: 1;
+}
+
+/* ---- Bookmarks bar mirror ---- */
+.bookmarks-bar {
+  margin-top: -32px;
+  margin-bottom: 32px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--warm-gray);
+  position: relative;
+}
+
+.bookmarks-bar-scroll {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  overflow: visible;
+  padding: 2px 0 4px;
+}
+
+.bookmarks-bar.collapsed .bookmarks-bar-scroll {
+  max-height: 72px;
+  overflow: hidden;
+  padding-right: 82px;
+}
+
+.bookmarks-bar.expanded .bookmarks-bar-scroll {
+  max-height: none;
+  padding-right: 0;
+}
+
+.bookmarks-expand-toggle {
+  position: absolute;
+  right: 0;
+  bottom: 14px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent-amber);
+  background: var(--control-bg);
+  border: 1px solid rgba(200, 113, 58, 0.28);
+  border-radius: 6px;
+  min-height: 30px;
+  padding: 5px 12px;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  box-shadow: -10px 0 18px var(--paper);
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.bookmarks-expand-toggle:hover {
+  background: rgba(200, 113, 58, 0.08);
+  border-color: var(--accent-amber);
+}
+
+:root[data-theme="dark"] .bookmarks-expand-toggle {
+  border-color: rgba(224, 154, 98, 0.3);
+}
+
+:root[data-theme="dark"] .bookmarks-expand-toggle:hover {
+  background: rgba(224, 154, 98, 0.1);
+}
+
+.bookmark-link,
+.bookmark-menu-link {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--ink);
+  text-decoration: none;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 30px;
+  max-width: 180px;
+  padding: 5px 9px;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.bookmark-link:hover,
+.bookmark-menu-link:hover {
+  background: var(--control-hover);
+  border-color: var(--warm-gray);
+  color: var(--ink);
+}
+
+.bookmark-link span,
+.bookmark-menu-link span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bookmark-favicon {
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.bookmark-folder {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.bookmark-folder summary {
+  list-style: none;
+  cursor: pointer;
+}
+
+.bookmark-folder summary::-webkit-details-marker {
+  display: none;
+}
+
+.bookmark-folder-icon {
+  width: 14px;
+  height: 10px;
+  border-radius: 3px 3px 2px 2px;
+  background: var(--accent-slate);
+  position: relative;
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+
+.bookmark-folder-icon::before {
+  content: '';
+  position: absolute;
+  left: 1px;
+  top: -3px;
+  width: 7px;
+  height: 4px;
+  border-radius: 2px 2px 0 0;
+  background: var(--accent-slate);
+}
+
+.bookmark-folder-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 20;
+  min-width: 220px;
+  max-width: min(320px, calc(100vw - 48px));
+  max-height: 360px;
+  overflow-y: auto;
+  padding: 8px;
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px var(--shadow);
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.bookmark-folder-menu::-webkit-scrollbar {
+  display: none;
+}
+
+.bookmark-folder.align-left .bookmark-folder-menu {
+  left: auto;
+  right: 0;
+}
+
+.bookmark-menu-link {
+  width: 100%;
+  max-width: none;
+  justify-content: flex-start;
 }
 
 /* ---- Nudge banner ---- */
@@ -337,6 +527,11 @@ header {
   border-radius: 3px;
 }
 
+.open-tabs-badge.duplicate-badge {
+  color: var(--accent-amber);
+  background: rgba(200, 113, 58, 0.08);
+}
+
 .open-tabs-badge svg {
   width: 10px;
   height: 10px;
@@ -376,12 +571,23 @@ header {
   border-bottom: none;
 }
 
+.page-chips-overflow {
+  display: contents;
+}
+
 /* Favicon */
 .chip-favicon {
   width: 16px;
   height: 16px;
   flex-shrink: 0;
   border-radius: 2px;
+}
+
+.deferred-favicon {
+  width: 14px;
+  height: 14px;
+  vertical-align: -2px;
+  margin-right: 4px;
 }
 
 /* Title text — wraps naturally, no truncation */
@@ -438,7 +644,7 @@ header {
 
 .chip-action:hover {
   opacity: 1;
-  background: rgba(154, 145, 138, 0.1);
+  background: var(--control-hover);
 }
 
 .chip-save:hover {
@@ -598,59 +804,6 @@ header {
   color: var(--status-active);
 }
 
-/* ---- Footer ---- */
-footer {
-  margin-top: 48px;
-  padding-top: 20px;
-  border-top: 1px solid var(--warm-gray);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.footer-stats {
-  display: flex;
-  gap: 32px;
-}
-
-.stat {
-  text-align: center;
-}
-
-.stat-num {
-  font-family: 'Newsreader', serif;
-  font-size: 28px;
-  font-weight: 300;
-  color: var(--ink);
-  line-height: 1;
-  transition: all 0.3s;
-}
-
-.stat-label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
-  color: var(--muted);
-  margin-top: 4px;
-}
-
-.last-refresh {
-  font-size: 11px;
-  color: var(--muted);
-}
-
-.refresh-btn {
-  font-family: 'DM Sans', sans-serif;
-  font-size: 11px;
-  font-weight: 500;
-  color: var(--accent-amber);
-  background: none;
-  border: none;
-  cursor: pointer;
-  text-decoration: underline;
-  text-underline-offset: 2px;
-}
-
 /* ---- Animations ---- */
 @keyframes fadeUp {
   from { opacity: 0; transform: translateY(12px); }
@@ -658,7 +811,6 @@ footer {
 }
 
 header { animation: fadeUp 0.5s ease both; }
-.tab-cleanup-banner { animation: fadeUp 0.5s ease 0.1s both; }
 .nudge-banner { animation: fadeUp 0.5s ease 0.15s both; }
 .active-section .section-header { animation: fadeUp 0.5s ease 0.2s both; }
 .active-section .missions .mission-card:nth-child(1) { animation: fadeUp 0.4s ease 0.25s both; }
@@ -669,7 +821,6 @@ header { animation: fadeUp 0.5s ease both; }
 .abandoned-section .missions .mission-card:nth-child(1) { animation: fadeUp 0.4s ease 0.5s both; }
 .abandoned-section .missions .mission-card:nth-child(2) { animation: fadeUp 0.4s ease 0.55s both; }
 .abandoned-section .missions .mission-card:nth-child(3) { animation: fadeUp 0.4s ease 0.6s both; }
-footer { animation: fadeUp 0.5s ease 0.65s both; }
 
 .deferred-list .deferred-item:nth-child(1) { animation-delay: 0.05s; }
 .deferred-list .deferred-item:nth-child(2) { animation-delay: 0.1s; }
@@ -677,6 +828,22 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 .deferred-list .deferred-item:nth-child(4) { animation-delay: 0.2s; }
 .deferred-list .deferred-item:nth-child(5) { animation-delay: 0.25s; }
 .deferred-column .section-header { animation: fadeUp 0.5s ease 0.1s both; }
+
+body.has-rendered-dashboard header,
+body.has-rendered-dashboard .header-left h1,
+body.has-rendered-dashboard .header-left .date,
+body.has-rendered-dashboard .header-right,
+body.has-rendered-dashboard .theme-toggle,
+body.has-rendered-dashboard .bookmarks-bar,
+body.has-rendered-dashboard .nudge-banner,
+body.has-rendered-dashboard .section-header,
+body.has-rendered-dashboard .section-count,
+body.has-rendered-dashboard .active-section .missions .mission-card,
+body.has-rendered-dashboard .deferred-list .deferred-item,
+body.has-rendered-dashboard .missions-empty-state,
+body.has-rendered-dashboard .empty-checkmark {
+  animation: none !important;
+}
 
 
 /* ================================================================
@@ -874,7 +1041,7 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 }
 
 .update-banner-dismiss:hover {
-  background: rgba(26, 22, 19, 0.06);
+  background: var(--control-hover);
   color: var(--ink);
 }
 
@@ -913,13 +1080,72 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 
 /* On narrow screens, stack vertically */
 @media (max-width: 800px) {
+  header {
+    align-items: center;
+    margin-bottom: 36px;
+  }
+
+  .theme-toggle {
+    padding: 7px 10px;
+  }
+
+  .bookmarks-bar {
+    margin-top: -20px;
+    margin-bottom: 28px;
+  }
+
+  .bookmark-link {
+    max-width: 150px;
+  }
+
   .dashboard-columns {
     flex-direction: column;
   }
+
+  .dashboard-columns .active-section {
+    min-width: 0;
+    width: 100%;
+  }
+
   .deferred-column {
     width: 100%;
     position: static;
   }
+}
+
+:root[data-theme="dark"] .mission-card {
+  border-color: rgba(241, 235, 226, 0.11);
+}
+
+:root[data-theme="dark"] .mission-card:hover {
+  box-shadow: 0 8px 24px var(--shadow);
+}
+
+:root[data-theme="dark"] .page-chip,
+:root[data-theme="dark"] .deferred-item,
+:root[data-theme="dark"] .archive-item {
+  border-bottom-color: rgba(241, 235, 226, 0.08);
+}
+
+:root[data-theme="dark"] .page-chip.clickable:hover {
+  background: rgba(224, 154, 98, 0.08);
+}
+
+:root[data-theme="dark"] .chip-save:hover {
+  background: rgba(138, 176, 148, 0.1);
+}
+
+:root[data-theme="dark"] .chip-close:hover {
+  background: rgba(223, 141, 141, 0.1);
+}
+
+:root[data-theme="dark"] .update-banner {
+  background: linear-gradient(135deg, rgba(138, 176, 148, 0.08), rgba(138, 176, 148, 0.14));
+  border-color: rgba(138, 176, 148, 0.24);
+}
+
+:root[data-theme="dark"] .archive-search {
+  border-color: rgba(241, 235, 226, 0.13);
 }
 
 /* ---- Checklist items ---- */
@@ -1155,4 +1381,10 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   color: var(--muted);
   opacity: 0.6;
   flex-shrink: 0;
+}
+
+.archive-no-results {
+  font-size: 12px;
+  color: var(--muted);
+  padding: 8px 0;
 }

--- a/extension/theme.js
+++ b/extension/theme.js
@@ -1,0 +1,14 @@
+(() => {
+  try {
+    const storedTheme = localStorage.getItem('tabOutTheme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const theme = storedTheme === 'dark' || storedTheme === 'light'
+      ? storedTheme
+      : prefersDark ? 'dark' : 'light';
+
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+  } catch {
+    // Leave the CSS default in place if localStorage or matchMedia is blocked.
+  }
+})();


### PR DESCRIPTION
## Summary

This PR polishes Tab Out’s new-tab experience with three user-facing improvements:

- Adds a dark mode with system preference support and a manual toggle
- Restores quick bookmark access by mirroring Chrome’s Bookmarks Bar inside Tab Out
- Replaces third-party favicon loading with Chrome’s local extension favicon endpoint

It also removes a few sources of visual friction: the duplicate Tab Out warning banner, the footer branding strip, heavy re-render animations during live updates, and CSP warnings from inline handlers.

## Why

Tab Out is already strong as a focused tab dashboard, but replacing Chrome’s new tab page removes some conveniences users expect from the native page. The biggest one is immediate access to bookmarks. Since Chrome does not expose a way for an extension new-tab override to force the native bookmarks bar to appear, this PR mirrors the user’s actual Bookmarks Bar folder via `chrome.bookmarks`.

Dark mode also matters for a new-tab replacement because users see it constantly, often at night or between tasks. The implementation keeps the existing warm editorial look rather than introducing a separate visual language.

Finally, the previous favicon approach used Google’s favicon service. This PR switches to Chrome’s built-in `_favicon` endpoint so favicon rendering stays local to the browser cache.

## Changes

### Dark mode

- Adds `extension/theme.js` to apply the saved or system theme before CSS paints
- Adds a header theme toggle
- Persists preference in `chrome.storage.local`
- Mirrors the theme to `localStorage` to avoid a flash on new-tab load
- Adds dark color tokens while preserving the current design language

### Bookmarks Bar mirror

- Adds a compact Bookmarks Bar section under the header
- Reads the real Bookmarks Bar via `chrome.bookmarks`
- Supports bookmark folders as dropdown menus
- Shows two bookmark rows by default
- Adds a `More` / `Less` control when bookmarks overflow
- Closes folder dropdowns when clicking outside
- Ensures only one folder dropdown is open at a time
- Aligns dropdowns left when near the right edge of the viewport
- Hides dropdown scrollbars while preserving scroll behavior

### Local favicon loading

- Replaces `https://www.google.com/s2/favicons` with Chrome’s extension favicon endpoint
- Adds the `favicon` permission
- Uses local browser favicon cache instead of a third-party service

### Live refresh and visual polish

- Adds live refresh listeners for tab changes:
  - create
  - close
  - update
  - move
  - attach/detach
  - replace
  - window focus
- Adds live refresh listeners for bookmark changes:
  - create
  - remove
  - change
  - move
  - reorder
  - import end
- Suppresses intro animations after the first dashboard render so repeated tab changes do not cause flicker
- Removes the duplicate Tab Out cleanup banner
- Groups multiple Tab Out pages as a normal `Tab Out` domain card
- Removes the in-page footer branding strip for a cleaner visual finish

### CSP cleanup

- Removes inline `onerror` handlers from generated images
- Removes inline `onerror` from optional `config.local.js`
- Loads optional local config dynamically from `app.js`
- Adds a CSP-safe captured image error listener
- Moves remaining generated inline styles into CSS classes

## New permissions

This PR adds:

- `bookmarks`: required to read the user’s Bookmarks Bar folder
- `favicon`: required for Chrome’s local `_favicon` endpoint

No server, account, or external API is introduced.

## Validation

Manually verified:

- New tab renders with the existing light theme
- Dark mode toggle switches theme and persists
- System dark preference is used when no manual preference is saved
- Bookmarks Bar renders from Chrome bookmarks
- Folder dropdowns open, close on outside click, and do not stack
- Overflowing bookmarks collapse to two rows with a `More` button
- Tab groups update when tabs are closed outside Tab Out
- Bookmark mirror updates after bookmark changes
- Duplicate Tab Out tabs now appear as a normal `Tab Out` card
- No CSP warning from inline handlers

Local checks run:

```powershell
node --check extension\app.js
node --check extension\theme.js
node -e "JSON.parse(require('fs').readFileSync('extension/manifest.json','utf8')); console.log('manifest ok')"
git diff --check
