### PR TITLE
feat: folder bar, folder management panel, global search, and render stability fixes

### DIFF
--- a/HANDOFF.txt
+++ b/HANDOFF.txt
@@ -1,0 +1,1452 @@
+================================================================================
+TAB OUT EXTENSION — FULL CODE CHANGE HANDOFF
+Sessions: April 2026 (two sessions, summarised below)
+Files changed: extension/app.js, extension/style.css, extension/index.html
+================================================================================
+
+This document contains every code change made across both sessions in full
+detail, including the exact before/after for each change and why each change
+was made. It is meant to be handed off to any developer or AI assistant to
+continue work without needing to re-read git history.
+
+================================================================================
+PART 1 — OVERVIEW OF ALL CHANGES
+================================================================================
+
+SESSION 1 — Bug fixes
+-----------------------
+1. Suppress double re-renders after intentional tab actions
+   (cards were flashing/re-animating 400ms after being deleted/saved)
+
+2. Stable domain card sort — added alphabetical tiebreaker so cards with equal
+   tab counts stop swapping positions between renders
+
+3. FLIP animation distance cap — cards that would travel > 250px now fade in
+   instead of flying diagonally across the screen
+
+SESSION 2 — Folder system (new feature)
+-----------------------------------------
+4. Full folder system: create, rename, delete, reorder folders
+   — both "Open Tabs" and "Saved for Later" sides
+   — drag-and-drop domain cards / saved items into folder headers
+   — per-item "Move to folder" button + folder picker popup
+   — inline rename (input replaces span, Enter/Escape/blur saves)
+   — up/down reorder for both folders and items within folders
+   — "changed X ago" timestamp on items when updatedAt is set
+
+5. Global search bar (Cmd/Ctrl+F style) — filters both columns in real time
+
+6. Folder Bar redesign (UI overhaul of folder navigation)
+   — horizontal chip strip above both columns
+   — "All" chip and one chip per folder
+   — active chip is visually larger (bigger padding, dark fill, bold)
+   — "New folder" dashed-border chip creates + activates + immediately renames
+   — "Manage" gear button reveals inline management panel
+   — focused folder view: both columns filter to just that folder's content,
+     archive is hidden, items render flat (no nested folder sections)
+   — delete auto-resets the active folder filter to "All"
+   — folder icon sizes fixed (increased from 11-12px to 14-16px everywhere)
+
+
+================================================================================
+PART 2 — extension/index.html
+================================================================================
+
+The only change to index.html in session 1 was adding the search bar and
+"New Folder" buttons to section headers. In session 2, the folder bar container
+was added. Below is the complete relevant HTML for all added elements.
+
+
+--- ADDED: Search bar (between header and dashboard-columns) ---
+
+  <div class="search-bar-wrap" id="searchBarWrap">
+    <span class="search-bar-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+           stroke-width="2" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round"
+              d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"/>
+      </svg>
+    </span>
+    <input type="text" class="search-bar" id="searchBar"
+           placeholder="Search tabs, saved items, folders…">
+    <button class="search-clear-btn" id="searchClearBtn" title="Clear search">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+           stroke-width="2.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+  </div>
+
+
+--- ADDED: Folder bar container (between search bar and dashboard-columns) ---
+
+  <div class="folder-bar-wrap" id="folderBarWrap" style="display:none">
+    <div class="folder-bar" id="folderBar"></div>
+    <div class="folder-manage-panel" id="folderManagePanel" style="display:none"></div>
+  </div>
+
+  Both elements start hidden. renderFolderBar() in app.js shows folderBarWrap
+  only when at least one folder exists. renderFolderManagePanel() toggles
+  folderManagePanel when the "Manage" button is clicked.
+
+
+--- ADDED: "New Folder" buttons in section headers ---
+
+  In the Open Tabs section header:
+    <button class="new-folder-btn" data-action="new-folder" data-section="open" title="New folder">
+      <svg .../>
+      Folder
+    </button>
+
+  In the Saved for Later section header:
+    <button class="new-folder-btn" data-action="new-folder" data-section="saved" title="New folder">
+      <svg .../>
+      Folder
+    </button>
+
+
+================================================================================
+PART 3 — extension/app.js  (all new/modified code in full)
+================================================================================
+
+------------------------------------------------------------------------
+3.1  MODULE-LEVEL STATE ADDITIONS  (after existing let activeWorkspace)
+------------------------------------------------------------------------
+
+// Last-loaded domain→folder map; kept in sync so reorderDomainCard can use it
+let _domainFolderMap = {};
+
+// Active folder filter — null = "All", folder id = show only that folder
+let activeFolderId = null;
+
+// Whether the folder management panel is expanded
+let _folderManagePanelOpen = false;
+
+
+------------------------------------------------------------------------
+3.2  UTILITY (added near module top)
+------------------------------------------------------------------------
+
+const escHtml = s => String(s ?? '')
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+
+------------------------------------------------------------------------
+3.3  FOLDER STORAGE HELPERS  (complete — all new in session 2)
+------------------------------------------------------------------------
+
+async function getFolders() {
+  const { folders = [] } = await chrome.storage.local.get('folders');
+  return folders.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}
+
+async function saveFolders(arr) {
+  await chrome.storage.local.set({ folders: arr });
+}
+
+async function createFolder(name) {
+  const folders = await getFolders();
+  const folder = {
+    id: 'f-' + Date.now(),
+    name: (name || 'New Folder').trim(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    order: folders.length,
+  };
+  folders.push(folder);
+  await saveFolders(folders);
+  return folder;
+}
+
+async function deleteFolder(id) {
+  const folders = (await getFolders()).filter(f => f.id !== id);
+  folders.forEach((f, i) => f.order = i);
+  await saveFolders(folders);
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  let dc = false;
+  deferred.forEach(x => { if (x.folderId === id) { x.folderId = null; dc = true; } });
+  if (dc) await chrome.storage.local.set({ deferred });
+  const { domainFolderMap = {} } = await chrome.storage.local.get('domainFolderMap');
+  let mc = false;
+  Object.keys(domainFolderMap).forEach(d => {
+    if (domainFolderMap[d] === id) { delete domainFolderMap[d]; mc = true; }
+  });
+  if (mc) await chrome.storage.local.set({ domainFolderMap });
+}
+
+async function moveFolderOrder(id, dir) {
+  const folders = await getFolders();
+  const i = folders.findIndex(f => f.id === id);
+  const j = dir === 'up' ? i - 1 : i + 1;
+  if (i < 0 || j < 0 || j >= folders.length) return;
+  [folders[i], folders[j]] = [folders[j], folders[i]];
+  folders.forEach((f, k) => f.order = k);
+  await saveFolders(folders);
+}
+
+async function setDomainFolder(domain, folderId) {
+  const { domainFolderMap = {} } = await chrome.storage.local.get('domainFolderMap');
+  if (folderId) domainFolderMap[domain] = folderId;
+  else          delete domainFolderMap[domain];
+  await chrome.storage.local.set({ domainFolderMap });
+  if (folderId) {
+    const folders = await getFolders();
+    const f = folders.find(x => x.id === folderId);
+    if (f) { f.updatedAt = Date.now(); await saveFolders(folders); }
+  }
+}
+
+async function setDeferredFolder(itemId, folderId) {
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  const item = deferred.find(x => x.id === itemId);
+  if (item) { item.folderId = folderId || null; item.updatedAt = Date.now(); }
+  await chrome.storage.local.set({ deferred });
+  if (folderId) {
+    const folders = await getFolders();
+    const f = folders.find(x => x.id === folderId);
+    if (f) { f.updatedAt = Date.now(); await saveFolders(folders); }
+  }
+}
+
+async function reorderDeferredItem(itemId, dir) {
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  const item = deferred.find(x => x.id === itemId);
+  if (!item) return;
+  const fid = item.folderId || null;
+  const sibs = deferred.filter(x => !x.dismissed && !x.completed && (x.folderId || null) === fid);
+  const si = sibs.findIndex(x => x.id === itemId);
+  const sj = dir === 'up' ? si - 1 : si + 1;
+  if (si < 0 || sj < 0 || sj >= sibs.length) return;
+  const di = deferred.indexOf(sibs[si]);
+  const dj = deferred.indexOf(sibs[sj]);
+  [deferred[di], deferred[dj]] = [deferred[dj], deferred[di]];
+  await chrome.storage.local.set({ deferred });
+}
+
+async function reorderDomainCard(domain, dir, folderId) {
+  const { domainFolderOrder = {} } = await chrome.storage.local.get('domainFolderOrder');
+  const key = folderId || '__root__';
+  const inFolder = domainGroups
+    .filter(g => (_domainFolderMap[g.domain] || null) === (folderId || null))
+    .map(g => g.domain);
+  let order = (domainFolderOrder[key] || []).filter(d => inFolder.includes(d));
+  inFolder.forEach(d => { if (!order.includes(d)) order.push(d); });
+  const i = order.indexOf(domain);
+  const j = dir === 'up' ? i - 1 : i + 1;
+  if (i < 0 || j < 0 || j >= order.length) return;
+  [order[i], order[j]] = [order[j], order[i]];
+  domainFolderOrder[key] = order;
+  await chrome.storage.local.set({ domainFolderOrder });
+}
+
+
+------------------------------------------------------------------------
+3.4  FLIP ANIMATION FIXES  (session 1 — in flipDomainCards function)
+------------------------------------------------------------------------
+
+The flipDomainCards() function was extended. After computing dx and dy:
+
+BEFORE (original):
+    card.style.transition = 'none';
+    card.style.transform  = `translate(${dx}px, ${dy}px)`;
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      card.style.transition = '';
+      card.style.transform  = '';
+    }));
+
+AFTER (with distance cap):
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist > 250) {
+      // Too far to animate smoothly — fade in at new position instead
+      card.style.transition = 'none';
+      card.style.opacity    = '0';
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        card.style.transition = 'opacity 0.3s ease';
+        card.style.opacity    = '';
+      }));
+      return;
+    }
+    // Normal FLIP for short-distance moves
+    card.style.transition = 'none';
+    card.style.transform  = `translate(${dx}px, ${dy}px)`;
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      card.style.transition = '';
+      card.style.transform  = '';
+    }));
+
+
+------------------------------------------------------------------------
+3.5  STABLE SORT  (session 1 — in renderStaticDashboard)
+------------------------------------------------------------------------
+
+BEFORE:
+  domainGroups = Object.values(groupMap).sort((a, b) => b.tabs.length - a.tabs.length);
+
+AFTER:
+  domainGroups = Object.values(groupMap).sort((a, b) => {
+    const diff = b.tabs.length - a.tabs.length;
+    return diff !== 0 ? diff : a.domain.localeCompare(b.domain);
+  });
+
+
+------------------------------------------------------------------------
+3.6  AUTO-REFRESH SUPPRESSION  (session 1)
+------------------------------------------------------------------------
+
+Added at module level (near __renderDebounceTimer):
+
+  let __renderDebounceTimer = null;
+  let __autoRefreshSuppressed = false;
+  let __autoRefreshSuppressTimer = null;
+
+  function suppressAutoRefresh(ms = 1200) {
+    __autoRefreshSuppressed = true;
+    clearTimeout(__autoRefreshSuppressTimer);
+    __autoRefreshSuppressTimer = setTimeout(() => {
+      __autoRefreshSuppressed = false;
+    }, ms);
+  }
+
+  function scheduleDashboardRefresh(delay = 400) {
+    if (__autoRefreshSuppressed) return;   // <-- NEW: bail early if suppressed
+    if (__renderDebounceTimer) clearTimeout(__renderDebounceTimer);
+    __renderDebounceTimer = setTimeout(() => {
+      __renderDebounceTimer = null;
+      renderStaticDashboard();
+    }, delay);
+  }
+
+suppressAutoRefresh() is called at the top of each action that intentionally
+closes browser tabs:
+  - 'close-single-tab' handler — before chrome.tabs.remove()
+  - 'defer-single-tab' handler — before chrome.tabs.remove()
+  - 'close-domain-tabs' handler — before closeTabsByUrls/closeTabsExact()
+  - 'save-domain-group' / 'archive-domain-group' handler — before close calls
+
+
+------------------------------------------------------------------------
+3.7  SVG CONSTANTS  (session 2 — added before render helpers)
+------------------------------------------------------------------------
+
+const FOLDER_SVG   = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v8.25A2.25 2.25 0 0 0 4.5 16.5h15a2.25 2.25 0 0 0 2.25-2.25V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"/></svg>`;
+const CHEVRON_DOWN = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>`;
+const CHEVRON_UP   = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5"/></svg>`;
+const PENCIL_SVG   = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Z"/></svg>`;
+const TRASH_SVG    = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg>`;
+const ADD_FOLDER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/></svg>`;
+const GEAR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94H9.75c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/></svg>`;
+
+
+function folderActionBtns(folderId) {
+  return `
+    <button class="tab-folder-btn" data-action="folder-up"   data-folder-id="${folderId}" title="Move folder up">${CHEVRON_UP}</button>
+    <button class="tab-folder-btn" data-action="folder-down" data-folder-id="${folderId}" title="Move folder down">${CHEVRON_DOWN}</button>
+    <button class="tab-folder-btn" data-action="rename-folder" data-folder-id="${folderId}" title="Rename">${PENCIL_SVG}</button>
+    <button class="tab-folder-btn danger" data-action="delete-folder" data-folder-id="${folderId}" title="Delete folder">${TRASH_SVG}</button>`;
+}
+
+
+------------------------------------------------------------------------
+3.8  FOLDER BAR RENDER FUNCTIONS  (session 2 — new, before renderStaticDashboard)
+------------------------------------------------------------------------
+
+function renderFolderBar(folders) {
+  const wrap = document.getElementById('folderBarWrap');
+  const bar  = document.getElementById('folderBar');
+  if (!bar || !wrap) return;
+
+  if (folders.length === 0) {
+    wrap.style.display = 'none';
+    return;
+  }
+
+  wrap.style.display = 'block';
+
+  const allActive = !activeFolderId ? ' active' : '';
+  let html = `<button class="folder-chip${allActive}" data-action="filter-folder" data-folder-id="">All</button>`;
+
+  for (const f of folders) {
+    const isActive = activeFolderId === f.id;
+    html += `<button class="folder-chip${isActive ? ' active' : ''}" data-action="filter-folder" data-folder-id="${escHtml(f.id)}">
+      ${FOLDER_SVG}<span class="folder-chip-name">${escHtml(f.name)}</span>
+    </button>`;
+  }
+
+  html += `<span class="folder-bar-spacer"></span>`;
+  html += `<button class="folder-chip-new" data-action="new-folder-bar" title="Create new folder">${ADD_FOLDER_SVG}New folder</button>`;
+  html += `<button class="folder-manage-toggle${_folderManagePanelOpen ? ' open' : ''}" data-action="toggle-folder-manage" title="Manage folders">${GEAR_SVG}Manage</button>`;
+
+  bar.innerHTML = html;
+}
+
+function renderFolderManagePanel(folders) {
+  const panel = document.getElementById('folderManagePanel');
+  if (!panel) return;
+
+  if (!_folderManagePanelOpen || folders.length === 0) {
+    panel.style.display = 'none';
+    return;
+  }
+
+  panel.style.display = 'block';
+  let html = `<div class="folder-manage-list">`;
+  for (const f of folders) {
+    html += `<div class="folder-manage-row" data-folder-id="${escHtml(f.id)}">
+      <span class="folder-manage-icon">${FOLDER_SVG}</span>
+      <span class="folder-manage-name">${escHtml(f.name)}</span>
+      <div class="folder-manage-btns">
+        <button data-action="folder-up"     data-folder-id="${escHtml(f.id)}" title="Move up">${CHEVRON_UP}</button>
+        <button data-action="folder-down"   data-folder-id="${escHtml(f.id)}" title="Move down">${CHEVRON_DOWN}</button>
+        <button data-action="rename-folder" data-folder-id="${escHtml(f.id)}" title="Rename">${PENCIL_SVG}</button>
+        <button class="danger" data-action="delete-folder" data-folder-id="${escHtml(f.id)}" title="Delete">${TRASH_SVG}</button>
+      </div>
+    </div>`;
+  }
+  html += `</div>`;
+  panel.innerHTML = html;
+}
+
+
+------------------------------------------------------------------------
+3.9  renderOpenTabsWithFolders()  (session 2 — complete updated version)
+------------------------------------------------------------------------
+
+  This function was rewritten to support the activeFolderId focused-view.
+  When activeFolderId is set, it renders cards for that folder only (flat,
+  no folder header cards). When null ("All"), the original behaviour
+  (folder header cards + cards + unfiled separator) is used.
+
+function renderOpenTabsWithFolders(folders, dfMap, domainFolderOrder) {
+  function orderedGroups(folderId) {
+    const key   = folderId || '__root__';
+    const inF   = domainGroups.filter(g => (dfMap[g.domain] || null) === (folderId || null));
+    const saved = (domainFolderOrder[key] || []).filter(d => inF.some(g => g.domain === d));
+    const rest  = inF.filter(g => !saved.includes(g.domain));
+    return [...saved.map(d => inF.find(g => g.domain === d)), ...rest].filter(Boolean);
+  }
+
+  // Folder-focused view — just show the cards for the active folder cleanly
+  if (activeFolderId) {
+    const groups = orderedGroups(activeFolderId);
+    if (groups.length === 0) {
+      return `<div class="folder-empty-state">No open tabs in this folder yet.</div>`;
+    }
+    return groups.map(g => renderDomainCard(g, activeFolderId, dfMap)).join('');
+  }
+
+  // "All" view — folder section headers + cards + unfiled
+  let html = '';
+  const hasFolderCards = folders.some(f => domainGroups.some(g => dfMap[g.domain] === f.id));
+
+  for (const folder of folders) {
+    const groups = orderedGroups(folder.id);
+    if (groups.length === 0) continue;
+    const ago = folder.updatedAt ? timeAgo(folder.updatedAt) : '';
+    html += `
+      <div class="tab-folder-header-card" data-action="toggle-tab-folder" data-folder-id="${folder.id}">
+        <svg class="tab-folder-chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+        <span>${FOLDER_SVG}</span>
+        <span class="tab-folder-name">${escHtml(folder.name)}</span>
+        <span class="tab-folder-count">${groups.length}</span>
+        ${ago ? `<span class="tab-folder-updated">${ago}</span>` : ''}
+        <div class="tab-folder-actions">${folderActionBtns(folder.id)}</div>
+      </div>`;
+    for (const g of groups) html += renderDomainCard(g, folder.id, dfMap);
+  }
+
+  const unfiled = orderedGroups(null);
+  if (unfiled.length > 0 && hasFolderCards) {
+    html += `<div class="tab-unfiled-sep"><span class="tab-unfiled-label">Unfiled</span><div class="tab-unfiled-line"></div></div>`;
+  }
+  for (const g of unfiled) html += renderDomainCard(g, null, dfMap);
+  return html;
+}
+
+
+------------------------------------------------------------------------
+3.10  renderStaticDashboard() — folder loading moved earlier  (session 2)
+------------------------------------------------------------------------
+
+  BEFORE: folder data was loaded inside the "if (domainGroups.length > 0)" block.
+  AFTER:  folder data is loaded unconditionally, then renderFolderBar +
+          renderFolderManagePanel are called before the domain-card block.
+
+  Key change excerpt (replaces the old in-block Promise.all):
+
+  // --- Load folder data (needed for bar + card rendering) ---
+  const [folders, dfMapRaw, { domainFolderOrder = {} }] = await Promise.all([
+    getFolders(),
+    chrome.storage.local.get('domainFolderMap'),
+    chrome.storage.local.get('domainFolderOrder'),
+  ]);
+  const dfMap = dfMapRaw.domainFolderMap || {};
+  _domainFolderMap = dfMap;
+
+  // Render global folder bar + management panel
+  renderFolderBar(folders);
+  renderFolderManagePanel(folders);
+
+  // --- Render domain cards ---
+  if (domainGroups.length > 0 && openTabsSection) {
+    // ... same as before but no longer loads folders here ...
+    const playFlip = flipDomainCards(openTabsMissionsEl);
+    openTabsMissionsEl.innerHTML = renderOpenTabsWithFolders(folders, dfMap, domainFolderOrder);
+    playFlip();
+    openTabsSection.style.display = 'block';
+  } else if (openTabsSection) {
+    openTabsSection.style.display = 'none';
+  }
+
+
+------------------------------------------------------------------------
+3.11  renderDeferredColumn() — folder filter + focused view  (session 2)
+------------------------------------------------------------------------
+
+  Three changes:
+
+  CHANGE A — filter active items when folder is focused:
+
+    BEFORE:
+      const active   = visible.filter(t => !t.completed);
+
+    AFTER:
+      let active = visible.filter(t => !t.completed);
+      if (activeFolderId) {
+        active = active.filter(x => x.folderId === activeFolderId);
+      }
+
+
+  CHANGE B — show empty state for folder rather than hiding column:
+
+    BEFORE:
+      if (active.length === 0 && archived.length === 0) {
+        column.style.display = 'none';
+        return;
+      }
+
+    AFTER:
+      if (active.length === 0 && (activeFolderId || archived.length === 0)) {
+        if (activeFolderId && active.length === 0) {
+          column.style.display = 'block';
+          list.innerHTML = `<div class="folder-empty-state">Nothing saved in this folder yet.</div>`;
+          list.style.display = 'block';
+          empty.style.display = 'none';
+          archiveEl.style.display = 'none';
+          countEl.textContent = '';
+          return;
+        }
+        column.style.display = 'none';
+        return;
+      }
+
+
+  CHANGE C — flat render when folder is focused, grouped when "All":
+
+    BEFORE:
+      if (active.length > 0) {
+        // always renders folder sections + unfiled
+
+    AFTER:
+      if (active.length > 0) {
+        countEl.textContent = `${active.length} item${active.length !== 1 ? 's' : ''}`;
+        const folders = await getFolders();
+        let html = '';
+
+        if (activeFolderId) {
+          // Focused folder — render items flat, no nested folder sections
+          html += active.map(item => item.kind === 'group'
+            ? renderDeferredGroup(item, storedIcons, liveWorkspaces)
+            : renderDeferredItem(item)
+          ).join('');
+        } else {
+          // "All" view — group by folder sections + unfiled
+          const hasFolderItems = folders.some(f => active.some(x => x.folderId === f.id));
+          for (const folder of folders) {
+            const inFolder = active.filter(x => x.folderId === folder.id);
+            if (inFolder.length === 0) continue;
+            html += renderSavedFolder(folder, inFolder, storedIcons, liveWorkspaces);
+          }
+          const unfiled = active.filter(x => !x.folderId);
+          if (unfiled.length > 0) {
+            if (hasFolderItems) {
+              html += `<div class="saved-unfiled-sep"><span class="saved-unfiled-label">Unfiled</span><div class="saved-unfiled-line"></div></div>`;
+            }
+            html += unfiled.map(item => item.kind === 'group'
+              ? renderDeferredGroup(item, storedIcons, liveWorkspaces)
+              : renderDeferredItem(item)
+            ).join('');
+          }
+        }
+        list.innerHTML = html;
+        ...
+      }
+
+
+  CHANGE D — hide archive section when folder filter is active:
+
+    BEFORE:
+      if (archived.length > 0) {
+
+    AFTER:
+      if (archived.length > 0 && !activeFolderId) {
+
+
+------------------------------------------------------------------------
+3.12  renderSavedFolder()  (session 2 — complete, new function)
+------------------------------------------------------------------------
+
+function renderSavedFolder(folder, items, storedIcons, liveWorkspaces) {
+  const ago = folder.updatedAt ? timeAgo(folder.updatedAt) : (folder.createdAt ? timeAgo(folder.createdAt) : '');
+  const actionBtns = `
+    <button class="saved-folder-btn" data-action="folder-up" data-folder-id="${folder.id}" title="Move up">${CHEVRON_UP}</button>
+    <button class="saved-folder-btn" data-action="folder-down" data-folder-id="${folder.id}" title="Move down">${CHEVRON_DOWN}</button>
+    <button class="saved-folder-btn" data-action="rename-folder" data-folder-id="${folder.id}" title="Rename">${PENCIL_SVG}</button>
+    <button class="saved-folder-btn danger" data-action="delete-folder" data-folder-id="${folder.id}" title="Delete">${TRASH_SVG}</button>`;
+  const body = items.map(item =>
+    item.kind === 'group'
+      ? renderDeferredGroup(item, storedIcons, liveWorkspaces)
+      : renderDeferredItem(item)
+  ).join('');
+  return `
+    <div class="saved-folder" data-saved-folder-id="${folder.id}">
+      <div class="saved-folder-header" data-action="toggle-saved-folder" data-folder-id="${folder.id}">
+        <svg class="saved-folder-chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+        <span class="saved-folder-name">${escHtml(folder.name)}</span>
+        <div class="saved-folder-meta">
+          <span>${items.length}</span>
+          ${ago ? `<span>· ${ago}</span>` : ''}
+        </div>
+        <div class="saved-folder-actions">${actionBtns}</div>
+      </div>
+      <div class="saved-folder-body">${body}</div>
+    </div>`;
+}
+
+
+------------------------------------------------------------------------
+3.13  renderDomainCard() — folder-aware additions  (session 2)
+------------------------------------------------------------------------
+
+  The card element was given:
+    draggable="true"
+    data-folder-id="${folderId || ''}"
+
+  New buttons were added to the card footer:
+    <!-- Move-to-folder button -->
+    <button class="move-folder-btn ${folderId ? 'in-folder' : ''}"
+      data-action="move-domain-to-folder"
+      data-domain="${escHtml(group.domain)}"
+      data-current-folder="${escHtml(folderId || '')}"
+      title="Move to folder">
+      ${FOLDER_SVG}
+    </button>
+
+    <!-- Up/down reorder buttons -->
+    <div class="card-reorder-btns">
+      <button class="card-reorder-btn" data-action="domain-up"
+        data-domain="${escHtml(group.domain)}"
+        data-folder-id="${escHtml(folderId || '')}" title="Move up">
+        ${CHEVRON_UP}
+      </button>
+      <button class="card-reorder-btn" data-action="domain-down"
+        data-domain="${escHtml(group.domain)}"
+        data-folder-id="${escHtml(folderId || '')}" title="Move down">
+        ${CHEVRON_DOWN}
+      </button>
+    </div>
+
+
+------------------------------------------------------------------------
+3.14  renderDeferredItem() — folder-aware additions  (session 2)
+------------------------------------------------------------------------
+
+  The item element was given:
+    draggable="true"
+
+  Left edge reorder buttons added:
+    <div class="reorder-btns">
+      <button class="reorder-btn" data-action="deferred-up"
+        data-deferred-id="${item.id}" title="Move up">
+        ${CHEVRON_UP SVG}
+      </button>
+      <button class="reorder-btn" data-action="deferred-down"
+        data-deferred-id="${item.id}" title="Move down">
+        ${CHEVRON_DOWN SVG}
+      </button>
+    </div>
+
+  Move-to-folder button added between deferred-info and deferred-restore:
+    <button class="item-folder-btn${item.folderId ? ' in-folder' : ''}"
+      data-action="move-saved-to-folder"
+      data-deferred-id="${item.id}"
+      data-current-folder="${escHtml(item.folderId || '')}"
+      title="Move to folder">
+      ${FOLDER_SVG}
+    </button>
+
+  Timestamp shows "changed X ago" if updatedAt is set:
+    <span>${changedAgo ? 'changed ' + changedAgo : savedAgo}</span>
+
+
+------------------------------------------------------------------------
+3.15  FOLDER ACTION HANDLERS  (session 2 — complete block)
+------------------------------------------------------------------------
+
+  Added as a separate document.addEventListener('click', async (e) => { ... })
+  block after the main action handler. Contains:
+
+  // ---- Filter by folder (folder bar chip click) ----
+  if (act === 'filter-folder') {
+    const fid = a.dataset.folderId || null;
+    if (activeFolderId === fid) return;
+    activeFolderId = fid;
+    await Promise.all([renderStaticDashboard(), renderDeferredColumn()]);
+    return;
+  }
+
+  // ---- Create new folder from the folder bar ----
+  if (act === 'new-folder-bar') {
+    const folder = await createFolder('New Folder');
+    activeFolderId = folder.id;
+    _folderManagePanelOpen = true;
+    await Promise.all([renderStaticDashboard(), renderDeferredColumn()]);
+    const nameEl = document.querySelector(`.folder-manage-row[data-folder-id="${folder.id}"] .folder-manage-name`);
+    if (nameEl) startFolderRename(nameEl, folder.id);
+    return;
+  }
+
+  // ---- Toggle folder management panel ----
+  if (act === 'toggle-folder-manage') {
+    _folderManagePanelOpen = !_folderManagePanelOpen;
+    const folders = await getFolders();
+    renderFolderManagePanel(folders);
+    document.querySelectorAll('[data-action="toggle-folder-manage"]')
+      .forEach(btn => btn.classList.toggle('open', _folderManagePanelOpen));
+    return;
+  }
+
+  // ---- Create new folder (section-level button) ----
+  if (act === 'new-folder') {
+    const section = a.dataset.section;
+    const folder = await createFolder('New Folder');
+    if (section === 'open') {
+      await renderStaticDashboard();
+    } else {
+      await renderDeferredColumn();
+    }
+    const nameEl = document.querySelector(`[data-folder-id="${folder.id}"] .tab-folder-name, [data-saved-folder-id="${folder.id}"] .saved-folder-name`);
+    if (nameEl) startFolderRename(nameEl, folder.id);
+    return;
+  }
+
+  // ---- Toggle open-tabs folder collapse ----
+  if (act === 'toggle-tab-folder') {
+    e.stopPropagation();
+    const folderId = a.dataset.folderId;
+    a.classList.toggle('collapsed');
+    const collapsed = a.classList.contains('collapsed');
+    document.querySelectorAll(`.mission-card[data-folder-id="${folderId}"]`)
+      .forEach(c => c.classList.toggle('folder-hidden', collapsed));
+    return;
+  }
+
+  // ---- Toggle saved-column folder collapse ----
+  if (act === 'toggle-saved-folder') {
+    e.stopPropagation();
+    const folder = a.closest('.saved-folder');
+    if (folder) folder.classList.toggle('collapsed');
+    return;
+  }
+
+  // ---- Rename folder ----
+  if (act === 'rename-folder') {
+    e.stopPropagation();
+    const folderId = a.dataset.folderId;
+    const nameEl = document.querySelector(
+      `.folder-manage-row[data-folder-id="${folderId}"] .folder-manage-name,
+       [data-action="toggle-tab-folder"][data-folder-id="${folderId}"] .tab-folder-name,
+       [data-action="toggle-saved-folder"][data-folder-id="${folderId}"] .saved-folder-name`
+    );
+    if (nameEl) startFolderRename(nameEl, folderId);
+    return;
+  }
+
+  // ---- Delete folder ----
+  if (act === 'delete-folder') {
+    e.stopPropagation();
+    const folderId = a.dataset.folderId;
+    if (activeFolderId === folderId) activeFolderId = null;  // reset filter
+    await deleteFolder(folderId);
+    await Promise.all([renderStaticDashboard(), renderDeferredColumn()]);
+    showToast('Folder deleted — items moved to unfiled');
+    return;
+  }
+
+  // ---- Reorder folder up / down ----
+  if (act === 'folder-up' || act === 'folder-down') {
+    e.stopPropagation();
+    const folderId = a.dataset.folderId;
+    await moveFolderOrder(folderId, act === 'folder-up' ? 'up' : 'down');
+    await Promise.all([renderStaticDashboard(), renderDeferredColumn()]);
+    return;
+  }
+
+  // ---- Move domain card to folder (show picker) ----
+  if (act === 'move-domain-to-folder') {
+    e.stopPropagation();
+    const domain    = a.dataset.domain;
+    const currentFo = a.dataset.currentFolder || null;
+    const folders   = await getFolders();
+    showFolderPicker(a, folders, currentFo, async (folderId) => {
+      await setDomainFolder(domain, folderId);
+      await renderStaticDashboard();
+    });
+    return;
+  }
+
+  // ---- Move saved item to folder (show picker) ----
+  if (act === 'move-saved-to-folder') {
+    e.stopPropagation();
+    const itemId    = a.dataset.deferredId;
+    const currentFo = a.dataset.currentFolder || null;
+    const folders   = await getFolders();
+    showFolderPicker(a, folders, currentFo, async (folderId) => {
+      await setDeferredFolder(itemId, folderId);
+      await renderDeferredColumn();
+    });
+    return;
+  }
+
+  // ---- Reorder saved item up / down ----
+  if (act === 'deferred-up' || act === 'deferred-down') {
+    e.stopPropagation();
+    const itemId = a.dataset.deferredId;
+    await reorderDeferredItem(itemId, act === 'deferred-up' ? 'up' : 'down');
+    await renderDeferredColumn();
+    return;
+  }
+
+  // ---- Reorder domain card up / down ----
+  if (act === 'domain-up' || act === 'domain-down') {
+    e.stopPropagation();
+    const domain   = a.dataset.domain;
+    const folderId = a.dataset.folderId || null;
+    await reorderDomainCard(domain, act === 'domain-up' ? 'up' : 'down', folderId || null);
+    await renderStaticDashboard();
+    return;
+  }
+
+
+------------------------------------------------------------------------
+3.16  FOLDER PICKER HELPER  (session 2 — new functions)
+------------------------------------------------------------------------
+
+let _folderPickerCallback = null;
+
+function showFolderPicker(anchor, folders, currentFolderId, onSelect) {
+  closeFolderPicker();
+  _folderPickerCallback = onSelect;
+
+  const picker = document.createElement('div');
+  picker.className = 'folder-picker';
+  picker.id = 'folderPicker';
+
+  const noFolderCls = !currentFolderId ? ' current' : '';
+  picker.innerHTML = `
+    <button class="folder-picker-item${noFolderCls}" data-pick-folder="">
+      <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/></svg>
+      No folder (unfiled)
+    </button>
+    ${folders.length ? '<div class="folder-picker-sep"></div>' : ''}
+    ${folders.map(f => {
+      const cls = f.id === currentFolderId ? ' current' : '';
+      return `<button class="folder-picker-item${cls}" data-pick-folder="${f.id}">
+        ${FOLDER_SVG} ${escHtml(f.name)}
+      </button>`;
+    }).join('')}`;
+
+  document.body.appendChild(picker);
+
+  const rect = anchor.getBoundingClientRect();
+  picker.style.top  = (rect.bottom + window.scrollY + 4) + 'px';
+  picker.style.left = (rect.left  + window.scrollX)     + 'px';
+
+  picker.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-pick-folder]');
+    if (!btn) return;
+    const fid = btn.dataset.pickFolder || null;
+    closeFolderPicker();
+    if (_folderPickerCallback) await _folderPickerCallback(fid);
+    _folderPickerCallback = null;
+  });
+}
+
+function closeFolderPicker() {
+  document.getElementById('folderPicker')?.remove();
+}
+
+// Close picker on outside click:
+document.addEventListener('click', (e) => {
+  if (!e.target.closest('.folder-picker')) closeFolderPicker();
+});
+
+
+------------------------------------------------------------------------
+3.17  FOLDER NAME INLINE EDIT  (session 2 — updated in session 2 round 2)
+------------------------------------------------------------------------
+
+function startFolderRename(nameEl, folderId) {
+  const oldName  = nameEl.textContent.trim();
+  const isTab    = nameEl.classList.contains('tab-folder-name');
+  const isManage = nameEl.classList.contains('folder-manage-name');
+  const cls      = isTab ? 'tab-folder-name-input' : isManage ? 'folder-manage-name-input' : 'saved-folder-name-input';
+
+  const input = document.createElement('input');
+  input.className = cls;
+  input.value     = oldName;
+  nameEl.replaceWith(input);
+  input.focus();
+  input.select();
+
+  async function save() {
+    const newName = input.value.trim() || oldName;
+    const folders = await getFolders();
+    const f = folders.find(x => x.id === folderId);
+    if (f) { f.name = newName; f.updatedAt = Date.now(); await saveFolders(folders); }
+    await Promise.all([renderStaticDashboard(), renderDeferredColumn()]);
+  }
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter')  { e.preventDefault(); save(); }
+    if (e.key === 'Escape') { input.value = oldName; save(); }
+  });
+  input.addEventListener('blur', save);
+}
+
+  NOTE: The isManage branch was added in the second session to support renaming
+  from the manage panel. The original only had isTab (tab-folder-name-input)
+  and the fallback (saved-folder-name-input).
+
+
+------------------------------------------------------------------------
+3.18  DRAG AND DROP  (session 2 — new IIFE)
+------------------------------------------------------------------------
+
+(function initDragAndDrop() {
+  // Domain cards → open-tabs folder headers
+  document.addEventListener('dragstart', (e) => {
+    const card = e.target.closest('.mission-card[data-domain]');
+    if (card) {
+      e.dataTransfer.setData('text/plain', JSON.stringify({ type: 'domain', domain: card.dataset.domain }));
+      e.dataTransfer.effectAllowed = 'move';
+      return;
+    }
+    const item = e.target.closest('.deferred-item[data-deferred-id], .deferred-group[data-group-id]');
+    if (item) {
+      const id = item.dataset.deferredId || item.dataset.groupId;
+      e.dataTransfer.setData('text/plain', JSON.stringify({ type: 'deferred', id }));
+      e.dataTransfer.effectAllowed = 'move';
+    }
+  });
+
+  document.addEventListener('dragover', (e) => {
+    const tabHeader   = e.target.closest('.tab-folder-header-card');
+    const savedHeader = e.target.closest('.saved-folder-header');
+    const target = tabHeader || savedHeader;
+    if (!target) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    target.classList.add('drop-target');
+  });
+
+  document.addEventListener('dragleave', (e) => {
+    const target = e.target.closest('.tab-folder-header-card, .saved-folder-header');
+    if (target) target.classList.remove('drop-target');
+  });
+
+  document.addEventListener('drop', async (e) => {
+    const tabHeader   = e.target.closest('.tab-folder-header-card');
+    const savedHeader = e.target.closest('.saved-folder-header');
+    const target = tabHeader || savedHeader;
+    if (!target) return;
+    target.classList.remove('drop-target');
+    e.preventDefault();
+    try {
+      const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+      const folderId = target.dataset.folderId;
+      if (data.type === 'domain' && tabHeader) {
+        await setDomainFolder(data.domain, folderId);
+        await renderStaticDashboard();
+      } else if (data.type === 'deferred' && savedHeader) {
+        await setDeferredFolder(data.id, folderId);
+        await renderDeferredColumn();
+      }
+    } catch {}
+  });
+})();
+
+
+------------------------------------------------------------------------
+3.19  GLOBAL SEARCH  (session 2 — new function + event listeners)
+------------------------------------------------------------------------
+
+function applySearch(query) {
+  const q = query.toLowerCase().trim();
+  const wrap = document.getElementById('searchBarWrap');
+  if (wrap) wrap.classList.toggle('has-query', q.length > 0);
+
+  // Filter open-tab domain cards
+  document.querySelectorAll('.mission-card[data-domain]').forEach(card => {
+    const domain = (card.dataset.domain || '').toLowerCase();
+    const titles = Array.from(card.querySelectorAll('.chip-text'))
+      .map(el => el.textContent.toLowerCase()).join(' ');
+    card.style.display = (!q || domain.includes(q) || titles.includes(q)) ? '' : 'none';
+  });
+
+  // Show/hide folder headers based on whether they have visible cards
+  document.querySelectorAll('.tab-folder-header-card[data-folder-id]').forEach(header => {
+    if (!q) { header.style.display = ''; return; }
+    const fid = header.dataset.folderId;
+    const anyVisible = Array.from(
+      document.querySelectorAll(`.mission-card[data-folder-id="${fid}"]`)
+    ).some(c => c.style.display !== 'none');
+    header.style.display = anyVisible ? '' : 'none';
+  });
+
+  // Filter saved items
+  document.querySelectorAll('.deferred-item[data-deferred-id]').forEach(item => {
+    const title  = (item.querySelector('.deferred-title')?.textContent || '').toLowerCase();
+    const domain = (item.querySelector('.deferred-meta span')?.textContent || '').toLowerCase();
+    item.style.display = (!q || title.includes(q) || domain.includes(q)) ? '' : 'none';
+  });
+
+  document.querySelectorAll('.deferred-group[data-group-id]').forEach(group => {
+    const label = (group.querySelector('.group-header-label')?.textContent || '').toLowerCase();
+    const texts = Array.from(group.querySelectorAll('.group-item-text'))
+      .map(el => el.textContent.toLowerCase()).join(' ');
+    group.style.display = (!q || label.includes(q) || texts.includes(q)) ? '' : 'none';
+  });
+
+  // Show/hide saved folder wrappers
+  document.querySelectorAll('.saved-folder[data-saved-folder-id]').forEach(sf => {
+    if (!q) { sf.style.display = ''; return; }
+    const anyVisible = Array.from(
+      sf.querySelectorAll('.deferred-item, .deferred-group')
+    ).some(el => el.style.display !== 'none');
+    sf.style.display = anyVisible ? '' : 'none';
+  });
+}
+
+// Input event listener:
+const searchBar = document.getElementById('searchBar');
+if (searchBar) {
+  searchBar.addEventListener('input', () => applySearch(searchBar.value));
+}
+const searchClearBtn = document.getElementById('searchClearBtn');
+if (searchClearBtn) {
+  searchClearBtn.addEventListener('click', () => {
+    if (searchBar) { searchBar.value = ''; applySearch(''); }
+  });
+}
+
+
+================================================================================
+PART 4 — extension/style.css  (all new CSS blocks added)
+================================================================================
+
+All new CSS was appended just before the "/* ---- Dark Mode ---- */" comment
+at the end of style.css.
+
+
+------------------------------------------------------------------------
+4.1  FOLDER BAR STYLES
+------------------------------------------------------------------------
+
+/* ================================================================
+   FOLDER BAR — global chip strip at the top of the content area
+   ================================================================ */
+
+.folder-bar-wrap {
+  margin-bottom: 20px;
+}
+
+.folder-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+}
+
+/* Base chip */
+.folder-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 13px;
+  border-radius: 20px;
+  border: 1.5px solid var(--warm-gray);
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  font-family: 'DM Sans', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s, background 0.15s,
+              padding 0.2s ease, font-size 0.2s ease, box-shadow 0.2s ease;
+}
+
+.folder-chip svg {
+  width: 14px; height: 14px;
+  flex-shrink: 0;
+  transition: width 0.2s, height 0.2s;
+}
+
+.folder-chip:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+/* Active (selected) chip — noticeably bigger */
+.folder-chip.active {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+  padding: 9px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.25);
+}
+
+.folder-chip.active svg {
+  width: 17px; height: 17px;
+}
+
+/* "New folder" chip — dashed outline */
+.folder-chip-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 12px;
+  border-radius: 20px;
+  border: 1.5px dashed var(--warm-gray);
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  font-family: 'DM Sans', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.folder-chip-new svg {
+  width: 12px; height: 12px;
+}
+
+.folder-chip-new:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+/* Spacer pushes "New folder" + "Manage" to the right */
+.folder-bar-spacer {
+  flex: 1;
+}
+
+/* Manage button */
+.folder-manage-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 11px;
+  border-radius: 20px;
+  border: 1.5px solid var(--warm-gray);
+  background: transparent;
+  color: var(--muted);
+  font-size: 11px;
+  font-family: 'DM Sans', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.folder-manage-toggle svg {
+  width: 13px; height: 13px;
+}
+
+.folder-manage-toggle:hover,
+.folder-manage-toggle.open {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+.folder-manage-toggle.open {
+  background: rgba(154,145,138,0.08);
+}
+
+
+------------------------------------------------------------------------
+4.2  FOLDER MANAGEMENT PANEL STYLES
+------------------------------------------------------------------------
+
+/* ================================================================
+   FOLDER MANAGEMENT PANEL — collapsible list below the bar
+   ================================================================ */
+
+.folder-manage-panel {
+  margin-top: 10px;
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray);
+  border-radius: 10px;
+  padding: 6px 10px;
+}
+
+.folder-manage-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.folder-manage-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 8px;
+  border-radius: 7px;
+  transition: background 0.12s;
+}
+
+.folder-manage-row:hover {
+  background: rgba(154,145,138,0.06);
+}
+
+.folder-manage-icon {
+  flex-shrink: 0;
+  display: flex;
+  color: var(--muted);
+}
+
+.folder-manage-icon svg {
+  width: 16px; height: 16px;
+}
+
+.folder-manage-name {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink);
+  min-width: 0;
+}
+
+.folder-manage-name-input {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: 'DM Sans', sans-serif;
+  background: none;
+  border: none;
+  border-bottom: 1.5px solid var(--accent-amber);
+  outline: none;
+  color: var(--ink);
+  padding: 0;
+  min-width: 0;
+}
+
+.folder-manage-btns {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.folder-manage-btns button {
+  width: 28px; height: 28px;
+  display: flex; align-items: center; justify-content: center;
+  background: none;
+  border: none;
+  border-radius: 5px;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.folder-manage-btns button:hover {
+  background: rgba(154,145,138,0.15);
+  color: var(--ink);
+}
+
+.folder-manage-btns button.danger:hover {
+  background: rgba(179,90,90,0.12);
+  color: var(--accent-rose);
+}
+
+.folder-manage-btns button svg {
+  width: 14px; height: 14px;
+}
+
+
+------------------------------------------------------------------------
+4.3  EMPTY STATE + ICON SIZE FIXES
+------------------------------------------------------------------------
+
+/* Empty state shown in the grid/list when a folder has no content */
+.folder-empty-state {
+  column-span: all;
+  font-size: 13px;
+  color: var(--muted);
+  padding: 24px 0 8px;
+  font-style: italic;
+}
+
+/* ================================================================
+   FOLDER ICON SIZE FIXES — increase from the previous too-small sizes
+   ================================================================ */
+
+.tab-folder-btn svg       { width: 15px !important; height: 15px !important; }
+.saved-folder-btn svg     { width: 14px !important; height: 14px !important; }
+.move-folder-btn svg      { width: 15px !important; height: 15px !important; }
+.item-folder-btn svg      { width: 15px !important; height: 15px !important; }
+.tab-folder-chevron       { width: 14px !important; height: 14px !important; }
+.saved-folder-chevron     { width: 13px !important; height: 13px !important; }
+.folder-picker-item svg   { width: 14px !important; height: 14px !important; }
+
+
+------------------------------------------------------------------------
+4.4  SEARCH BAR STYLES
+------------------------------------------------------------------------
+
+/* ================================================================
+   SEARCH BAR
+   ================================================================ */
+.search-bar-wrap {
+  position: relative; margin-bottom: 28px;
+}
+.search-bar {
+  width: 100%;
+  padding: 10px 36px 10px 38px;
+  font-family: 'DM Sans', sans-serif; font-size: 13px;
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray); border-radius: 8px;
+  color: var(--ink); outline: none;
+  transition: border-color 0.2s;
+}
+.search-bar:focus { border-color: var(--accent-amber); }
+.search-bar::placeholder { color: var(--muted); }
+
+.search-bar-icon {
+  position: absolute; left: 12px; top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted); pointer-events: none; display: flex;
+}
+.search-bar-icon svg { width: 15px; height: 15px; }
+
+.search-clear-btn {
+  position: absolute; right: 10px; top: 50%;
+  transform: translateY(-50%);
+  background: none; border: none; cursor: pointer;
+  color: var(--muted); padding: 3px; border-radius: 3px;
+  display: none; align-items: center;
+  transition: color 0.15s;
+}
+.search-bar-wrap.has-query .search-clear-btn { display: flex; }
+.search-clear-btn:hover { color: var(--ink); }
+.search-clear-btn svg { width: 12px; height: 12px; }
+
+mark.search-hit {
+  background: rgba(200,113,58,0.18); color: inherit;
+  border-radius: 2px; padding: 0 1px;
+}
+
+
+------------------------------------------------------------------------
+4.5  FOLDER SYSTEM STYLES  (collapsible headers, unfiled separators, pickers)
+------------------------------------------------------------------------
+
+These classes already existed in the original CSS and were NOT changed.
+They are listed here for reference only:
+
+  .tab-folder-header-card       — column-spanning folder header in the card grid
+  .tab-folder-chevron           — collapse chevron
+  .tab-folder-name              — folder name span
+  .tab-folder-name-input        — inline rename input
+  .tab-folder-count             — small count badge
+  .tab-folder-updated           — "X ago" italic label
+  .tab-folder-actions           — action button row (fade in on hover)
+  .tab-folder-btn               — individual action button
+  .tab-unfiled-sep              — "Unfiled" divider spanning all columns
+  .mission-card.folder-hidden   — display:none when folder is collapsed
+  .new-folder-btn               — dashed "Folder" button in section headers
+  .move-folder-btn              — folder icon button on domain cards
+  .card-reorder-btns            — up/down reorder button pair on domain cards
+  .saved-folder                 — saved-column folder wrapper
+  .saved-folder-header          — clickable folder header
+  .saved-folder-chevron         — collapse chevron
+  .saved-folder-name            — folder name span
+  .saved-folder-name-input      — inline rename input
+  .saved-folder-meta            — count + time meta
+  .saved-folder-actions         — action button row (fade in on hover)
+  .saved-folder-btn             — individual action button
+  .saved-folder-body            — folder item list
+  .saved-unfiled-sep            — "Unfiled" divider in saved column
+  .reorder-btns                 — up/down pair on saved items
+  .reorder-btn                  — individual reorder button
+  .item-folder-btn              — folder icon button on saved items
+  .folder-picker                — fixed-position folder picker dropdown
+  .folder-picker-item           — individual picker row
+  .folder-picker-sep            — divider line inside picker
+  .drop-target                  — dashed amber outline when dragging over
+
+
+================================================================================
+PART 5 — CHROME STORAGE SCHEMA
+================================================================================
+
+All data persists in chrome.storage.local. New keys added:
+
+  Key: 'folders'
+  Shape: Array<{
+    id: string,         // 'f-' + Date.now()
+    name: string,
+    order: number,      // 0-indexed sort position
+    createdAt: number,  // Date.now() timestamp
+    updatedAt: number,  // Date.now() timestamp, updated on rename/assignment
+  }>
+
+  Key: 'domainFolderMap'
+  Shape: { [domain: string]: folderId | undefined }
+  — maps a hostname (e.g. "github.com") to a folder id
+  — key is deleted when domain is moved to "unfiled"
+
+  Key: 'domainFolderOrder'
+  Shape: { [key: string]: string[] }
+  — key is folderId or '__root__' (unfiled)
+  — value is an ordered array of domain strings
+  — used to persist user-defined card order within each folder
+
+  Key: 'deferred'  (pre-existing, extended)
+  — each item / group entry now optionally has:
+      folderId: string | null    — folder assignment
+      updatedAt: number          — timestamp when folderId last changed
+
+
+================================================================================
+PART 6 — DATA-ACTION SUMMARY  (all new data-action values added)
+================================================================================
+
+  filter-folder          — folder bar chip click; sets activeFolderId
+  new-folder-bar         — "New folder" chip in bar; creates + activates + opens manage
+  toggle-folder-manage   — gear "Manage" button; toggles _folderManagePanelOpen
+  new-folder             — section-level "Folder" button; creates in context section
+  toggle-tab-folder      — fold/unfold folder section in open-tabs grid
+  toggle-saved-folder    — fold/unfold folder section in saved column
+  rename-folder          — triggers startFolderRename on nearest name element
+  delete-folder          — deletes folder; resets activeFolderId if it was active
+  folder-up / folder-down — reorders folder in the global folder list
+  move-domain-to-folder  — shows folder picker for a domain card
+  move-saved-to-folder   — shows folder picker for a saved item
+  domain-up / domain-down — reorders a domain card within its folder slot
+  deferred-up / deferred-down — reorders a saved item within its folder slot
+
+
+================================================================================
+END OF HANDOFF
+================================================================================

--- a/extension/app.js
+++ b/extension/app.js
@@ -907,6 +907,132 @@ let domainGroups = [];
 // Opera GX workspace filter — null = "All", otherwise a workspaceId string
 let activeWorkspace = null;
 
+// Last-loaded domain→folder map; kept in sync so reorderDomainCard can use it
+let _domainFolderMap = {};
+
+// Active folder filter — null = "All", folder id = show only that folder
+let activeFolderId = null;
+
+// Whether the folder management panel is expanded
+let _folderManagePanelOpen = false;
+
+
+/* ----------------------------------------------------------------
+   UTILITY
+   ---------------------------------------------------------------- */
+const escHtml = s => String(s ?? '')
+  .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+
+/* ----------------------------------------------------------------
+   FOLDER STORAGE HELPERS
+   ---------------------------------------------------------------- */
+
+async function getFolders() {
+  const { folders = [] } = await chrome.storage.local.get('folders');
+  return folders.sort((a, b) => (a.order ?? 0) - (b.order ?? 0));
+}
+
+async function saveFolders(arr) {
+  await chrome.storage.local.set({ folders: arr });
+}
+
+async function createFolder(name) {
+  const folders = await getFolders();
+  const folder = {
+    id: 'f-' + Date.now(),
+    name: (name || 'New Folder').trim(),
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    order: folders.length,
+  };
+  folders.push(folder);
+  await saveFolders(folders);
+  return folder;
+}
+
+async function deleteFolder(id) {
+  const folders = (await getFolders()).filter(f => f.id !== id);
+  folders.forEach((f, i) => f.order = i);
+  await saveFolders(folders);
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  let dc = false;
+  deferred.forEach(x => { if (x.folderId === id) { x.folderId = null; dc = true; } });
+  if (dc) await chrome.storage.local.set({ deferred });
+  const { domainFolderMap = {} } = await chrome.storage.local.get('domainFolderMap');
+  let mc = false;
+  Object.keys(domainFolderMap).forEach(d => {
+    if (domainFolderMap[d] === id) { delete domainFolderMap[d]; mc = true; }
+  });
+  if (mc) await chrome.storage.local.set({ domainFolderMap });
+}
+
+async function moveFolderOrder(id, dir) {
+  const folders = await getFolders();
+  const i = folders.findIndex(f => f.id === id);
+  const j = dir === 'up' ? i - 1 : i + 1;
+  if (i < 0 || j < 0 || j >= folders.length) return;
+  [folders[i], folders[j]] = [folders[j], folders[i]];
+  folders.forEach((f, k) => f.order = k);
+  await saveFolders(folders);
+}
+
+async function setDomainFolder(domain, folderId) {
+  const { domainFolderMap = {} } = await chrome.storage.local.get('domainFolderMap');
+  if (folderId) domainFolderMap[domain] = folderId;
+  else          delete domainFolderMap[domain];
+  await chrome.storage.local.set({ domainFolderMap });
+  if (folderId) {
+    const folders = await getFolders();
+    const f = folders.find(x => x.id === folderId);
+    if (f) { f.updatedAt = Date.now(); await saveFolders(folders); }
+  }
+}
+
+async function setDeferredFolder(itemId, folderId) {
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  const item = deferred.find(x => x.id === itemId);
+  if (item) { item.folderId = folderId || null; item.updatedAt = Date.now(); }
+  await chrome.storage.local.set({ deferred });
+  if (folderId) {
+    const folders = await getFolders();
+    const f = folders.find(x => x.id === folderId);
+    if (f) { f.updatedAt = Date.now(); await saveFolders(folders); }
+  }
+}
+
+async function reorderDeferredItem(itemId, dir) {
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  const item = deferred.find(x => x.id === itemId);
+  if (!item) return;
+  const fid = item.folderId || null;
+  const sibs = deferred.filter(x => !x.dismissed && !x.completed && (x.folderId || null) === fid);
+  const si = sibs.findIndex(x => x.id === itemId);
+  const sj = dir === 'up' ? si - 1 : si + 1;
+  if (si < 0 || sj < 0 || sj >= sibs.length) return;
+  const di = deferred.indexOf(sibs[si]);
+  const dj = deferred.indexOf(sibs[sj]);
+  [deferred[di], deferred[dj]] = [deferred[dj], deferred[di]];
+  await chrome.storage.local.set({ deferred });
+}
+
+async function reorderDomainCard(domain, dir, folderId) {
+  const { domainFolderOrder = {} } = await chrome.storage.local.get('domainFolderOrder');
+  const key = folderId || '__root__';
+  const inFolder = domainGroups
+    .filter(g => (_domainFolderMap[g.domain] || null) === (folderId || null))
+    .map(g => g.domain);
+  let order = (domainFolderOrder[key] || []).filter(d => inFolder.includes(d));
+  inFolder.forEach(d => { if (!order.includes(d)) order.push(d); });
+  const i = order.indexOf(domain);
+  const j = dir === 'up' ? i - 1 : i + 1;
+  if (i < 0 || j < 0 || j >= order.length) return;
+  [order[i], order[j]] = [order[j], order[i]];
+  domainFolderOrder[key] = order;
+  await chrome.storage.local.set({ domainFolderOrder });
+}
+
 // Curated emoji library used by the workspace icon picker.
 // Grouped by category; the free-form input below accepts anything else.
 const EMOJI_CATEGORIES = [
@@ -994,12 +1120,12 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
    ---------------------------------------------------------------- */
 
 /**
- * renderDomainCard(group, groupIndex)
+ * renderDomainCard(group, folderId, domainFolderMap)
  *
  * Builds the HTML for one domain group card.
  * group = { domain: string, tabs: [{ url, title, id, windowId, active }] }
  */
-function renderDomainCard(group) {
+function renderDomainCard(group, folderId, domainFolderMap) {
   const tabs      = group.tabs || [];
   const tabCount  = tabs.length;
   const stableId  = 'domain-' + group.domain.replace(/[^a-z0-9]/g, '-');
@@ -1089,8 +1215,33 @@ function renderDomainCard(group) {
       </button>`;
   }
 
+  // Folder-related extras
+  const currentFolderId = folderId || null;
+  const folderBtnClass  = currentFolderId ? ' in-folder' : '';
+  const folderSvg = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v8.25A2.25 2.25 0 0 0 4.5 16.5h15a2.25 2.25 0 0 0 2.25-2.25V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"/></svg>`;
+  const upSvg   = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5"/></svg>`;
+  const downSvg = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>`;
+
+  const folderRow = `
+    <div style="display:flex;align-items:center;gap:4px;margin-top:8px">
+      <button class="move-folder-btn${folderBtnClass}" data-action="move-domain-to-folder"
+        data-domain="${group.domain}" data-current-folder="${escHtml(currentFolderId || '')}"
+        title="Move to folder">${folderSvg}${currentFolderId ? '' : ''}</button>
+      <div class="card-reorder-btns">
+        <button class="card-reorder-btn" data-action="domain-up"
+          data-domain="${group.domain}" data-folder-id="${escHtml(currentFolderId || '')}"
+          title="Move card up">${upSvg}</button>
+        <button class="card-reorder-btn" data-action="domain-down"
+          data-domain="${group.domain}" data-folder-id="${escHtml(currentFolderId || '')}"
+          title="Move card down">${downSvg}</button>
+      </div>
+    </div>`;
+
   return `
-    <div class="mission-card domain-card ${hasDupes ? 'has-amber-bar' : 'has-neutral-bar'}" data-domain-id="${stableId}" data-domain="${group.domain}">
+    <div class="mission-card domain-card ${hasDupes ? 'has-amber-bar' : 'has-neutral-bar'}"
+         data-domain-id="${stableId}" data-domain="${group.domain}"
+         data-folder-id="${escHtml(currentFolderId || '')}"
+         draggable="true">
       <div class="status-bar"></div>
       <div class="mission-content">
         <div class="mission-top">
@@ -1100,6 +1251,7 @@ function renderDomainCard(group) {
         </div>
         <div class="mission-pages">${pageChips}</div>
         <div class="actions">${actionsHtml}</div>
+        ${folderRow}
       </div>
       <div class="mission-meta">
         <div class="mission-page-count">${tabCount}</div>
@@ -1147,25 +1299,65 @@ async function renderDeferredColumn() {
 
     // Derive visible subsets AFTER migration so render sees fresh names.
     const visible  = deferred.filter(t => !t.dismissed);
-    const active   = visible.filter(t => !t.completed);
+    let   active   = visible.filter(t => !t.completed);
     const archived = visible.filter(t => t.completed);
 
+    // Apply folder filter when a specific folder is active
+    if (activeFolderId) {
+      active = active.filter(x => x.folderId === activeFolderId);
+    }
+
     // Hide the entire column if there's nothing to show
-    if (active.length === 0 && archived.length === 0) {
+    if (active.length === 0 && (activeFolderId || archived.length === 0)) {
+      if (activeFolderId && active.length === 0) {
+        // Show empty state for the folder rather than hiding the column entirely
+        column.style.display = 'block';
+        list.innerHTML = `<div class="folder-empty-state">Nothing saved in this folder yet.</div>`;
+        list.style.display = 'block';
+        empty.style.display = 'none';
+        archiveEl.style.display = 'none';
+        countEl.textContent = '';
+        return;
+      }
       column.style.display = 'none';
       return;
     }
 
     column.style.display = 'block';
 
-    // Render active checklist items (mix of individual tabs and saved groups)
+    // Render active checklist items
     if (active.length > 0) {
       countEl.textContent = `${active.length} item${active.length !== 1 ? 's' : ''}`;
-      list.innerHTML = active
-        .map(item => item.kind === 'group'
+      const folders = await getFolders();
+      let html = '';
+
+      if (activeFolderId) {
+        // Focused folder — render items flat, no nested folder sections
+        html += active.map(item => item.kind === 'group'
           ? renderDeferredGroup(item, storedIcons, liveWorkspaces)
-          : renderDeferredItem(item))
-        .join('');
+          : renderDeferredItem(item)
+        ).join('');
+      } else {
+        // "All" view — group by folder sections + unfiled
+        const hasFolderItems = folders.some(f => active.some(x => x.folderId === f.id));
+        for (const folder of folders) {
+          const inFolder = active.filter(x => x.folderId === folder.id);
+          if (inFolder.length === 0) continue;
+          html += renderSavedFolder(folder, inFolder, storedIcons, liveWorkspaces);
+        }
+        const unfiled = active.filter(x => !x.folderId);
+        if (unfiled.length > 0) {
+          if (hasFolderItems) {
+            html += `<div class="saved-unfiled-sep"><span class="saved-unfiled-label">Unfiled</span><div class="saved-unfiled-line"></div></div>`;
+          }
+          html += unfiled.map(item => item.kind === 'group'
+            ? renderDeferredGroup(item, storedIcons, liveWorkspaces)
+            : renderDeferredItem(item)
+          ).join('');
+        }
+      }
+
+      list.innerHTML = html;
       list.style.display = 'block';
       empty.style.display = 'none';
     } else {
@@ -1174,8 +1366,8 @@ async function renderDeferredColumn() {
       empty.style.display = 'block';
     }
 
-    // Render archive section (mix of individual tabs and archived groups)
-    if (archived.length > 0) {
+    // Render archive section — hidden when a folder filter is active
+    if (archived.length > 0 && !activeFolderId) {
       archiveCountEl.textContent = `(${archived.length})`;
       archiveList.innerHTML = archived
         .map(item => item.kind === 'group'
@@ -1203,19 +1395,32 @@ function renderDeferredItem(item) {
   let domain = '';
   try { domain = new URL(item.url).hostname.replace(/^www\./, ''); } catch {}
   const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=16`;
-  const ago = timeAgo(item.savedAt);
+  const savedAgo   = timeAgo(item.savedAt);
+  const changedAgo = item.updatedAt ? timeAgo(item.updatedAt) : null;
+  const folderCls  = item.folderId ? ' in-folder' : '';
 
   return `
-    <div class="deferred-item" data-deferred-id="${item.id}">
+    <div class="deferred-item" data-deferred-id="${item.id}" draggable="true">
+      <div class="reorder-btns">
+        <button class="reorder-btn" data-action="deferred-up" data-deferred-id="${item.id}" title="Move up">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5"/></svg>
+        </button>
+        <button class="reorder-btn" data-action="deferred-down" data-deferred-id="${item.id}" title="Move down">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+        </button>
+      </div>
       <div class="deferred-info">
         <a href="${item.url}" target="_blank" rel="noopener" class="deferred-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
           <img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px">${item.title || item.url}
         </a>
         <div class="deferred-meta">
           <span>${domain}</span>
-          <span>${ago}</span>
+          <span>${changedAgo ? 'changed ' + changedAgo : savedAgo}</span>
         </div>
       </div>
+      <button class="item-folder-btn${folderCls}" data-action="move-saved-to-folder"
+        data-deferred-id="${item.id}" data-current-folder="${escHtml(item.folderId || '')}"
+        title="Move to folder">${FOLDER_SVG}</button>
       <button class="deferred-restore" data-action="restore-deferred" data-deferred-id="${item.id}" title="Reopen as a tab">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
       </button>
@@ -1337,9 +1542,20 @@ function renderDeferredGroup(group, storedIcons = {}, liveWorkspaces = new Map()
       </div>`;
   }).join('');
 
+  const folderCls = group.folderId ? ' in-folder' : '';
+  const changedAgo = group.updatedAt ? timeAgo(group.updatedAt) : null;
+
   return `
-    <div class="deferred-group" data-group-id="${group.id}">
+    <div class="deferred-group" data-group-id="${group.id}" draggable="true">
       <div class="group-header">
+        <div class="reorder-btns">
+          <button class="reorder-btn" data-action="deferred-up" data-deferred-id="${group.id}" title="Move up">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5"/></svg>
+          </button>
+          <button class="reorder-btn" data-action="deferred-down" data-deferred-id="${group.id}" title="Move down">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+          </button>
+        </div>
         <button class="group-toggle" data-action="toggle-group" data-group-id="${group.id}" title="Expand/collapse">
           <svg class="group-chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
         </button>
@@ -1349,8 +1565,11 @@ function renderDeferredGroup(group, storedIcons = {}, liveWorkspaces = new Map()
             <span class="group-header-label">${group.label || 'Group'}</span>
             <span class="group-header-count">${count} tab${count !== 1 ? 's' : ''}</span>
           </div>
-          <div class="group-header-meta">${metaHtml}</div>
+          <div class="group-header-meta">${changedAgo ? 'changed ' + changedAgo + ' · ' : ''}${metaHtml}</div>
         </div>
+        <button class="item-folder-btn${folderCls}" data-action="move-saved-to-folder"
+          data-deferred-id="${group.id}" data-current-folder="${escHtml(group.folderId || '')}"
+          title="Move to folder">${FOLDER_SVG}</button>
         <button class="group-header-action" data-action="restore-group-all" data-group-id="${group.id}" title="Reopen all tabs">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
         </button>
@@ -1504,6 +1723,18 @@ function flipDomainCards(container) {
         const dy = oldRect.top  - newRect.top;
         if (dx === 0 && dy === 0) return;
 
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        if (dist > 250) {
+          // Too far to animate smoothly — fade in at new position instead
+          card.style.transition = 'none';
+          card.style.opacity    = '0';
+          requestAnimationFrame(() => requestAnimationFrame(() => {
+            card.style.transition = 'opacity 0.3s ease';
+            card.style.opacity    = '';
+          }));
+          return;
+        }
+
         card.style.transition = 'none';
         card.style.transform  = `translate(${dx}px, ${dy}px)`;
 
@@ -1521,6 +1752,160 @@ function flipDomainCards(container) {
       }
     });
   };
+}
+
+/* ----------------------------------------------------------------
+   FOLDER RENDER HELPERS
+   ---------------------------------------------------------------- */
+
+const FOLDER_SVG   = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v8.25A2.25 2.25 0 0 0 4.5 16.5h15a2.25 2.25 0 0 0 2.25-2.25V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"/></svg>`;
+const CHEVRON_DOWN = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>`;
+const CHEVRON_UP   = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 15.75 7.5-7.5 7.5 7.5"/></svg>`;
+const PENCIL_SVG   = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Z"/></svg>`;
+const TRASH_SVG    = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/></svg>`;
+
+function folderActionBtns(folderId) {
+  return `
+    <button class="tab-folder-btn" data-action="folder-up" data-folder-id="${folderId}" title="Move folder up">${CHEVRON_UP}</button>
+    <button class="tab-folder-btn" data-action="folder-down" data-folder-id="${folderId}" title="Move folder down">${CHEVRON_DOWN}</button>
+    <button class="tab-folder-btn" data-action="rename-folder" data-folder-id="${folderId}" title="Rename">${PENCIL_SVG}</button>
+    <button class="tab-folder-btn danger" data-action="delete-folder" data-folder-id="${folderId}" title="Delete folder">${TRASH_SVG}</button>`;
+}
+
+function renderOpenTabsWithFolders(folders, dfMap, domainFolderOrder) {
+  function orderedGroups(folderId) {
+    const key   = folderId || '__root__';
+    const inF   = domainGroups.filter(g => (dfMap[g.domain] || null) === (folderId || null));
+    const saved = (domainFolderOrder[key] || []).filter(d => inF.some(g => g.domain === d));
+    const rest  = inF.filter(g => !saved.includes(g.domain));
+    return [...saved.map(d => inF.find(g => g.domain === d)), ...rest].filter(Boolean);
+  }
+
+  // Folder-focused view — just show the cards for the active folder cleanly
+  if (activeFolderId) {
+    const groups = orderedGroups(activeFolderId);
+    if (groups.length === 0) {
+      return `<div class="folder-empty-state">No open tabs in this folder yet.</div>`;
+    }
+    return groups.map(g => renderDomainCard(g, activeFolderId, dfMap)).join('');
+  }
+
+  // "All" view — folder section headers + cards + unfiled
+  let html = '';
+  const hasFolderCards = folders.some(f => domainGroups.some(g => dfMap[g.domain] === f.id));
+
+  for (const folder of folders) {
+    const groups = orderedGroups(folder.id);
+    if (groups.length === 0) continue;
+    const ago = folder.updatedAt ? timeAgo(folder.updatedAt) : '';
+    html += `
+      <div class="tab-folder-header-card" data-action="toggle-tab-folder" data-folder-id="${folder.id}">
+        <svg class="tab-folder-chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+        <span>${FOLDER_SVG}</span>
+        <span class="tab-folder-name">${escHtml(folder.name)}</span>
+        <span class="tab-folder-count">${groups.length}</span>
+        ${ago ? `<span class="tab-folder-updated">${ago}</span>` : ''}
+        <div class="tab-folder-actions">${folderActionBtns(folder.id)}</div>
+      </div>`;
+    for (const g of groups) html += renderDomainCard(g, folder.id, dfMap);
+  }
+
+  const unfiled = orderedGroups(null);
+  if (unfiled.length > 0 && hasFolderCards) {
+    html += `<div class="tab-unfiled-sep"><span class="tab-unfiled-label">Unfiled</span><div class="tab-unfiled-line"></div></div>`;
+  }
+  for (const g of unfiled) html += renderDomainCard(g, null, dfMap);
+  return html;
+}
+
+function renderSavedFolder(folder, items, storedIcons, liveWorkspaces) {
+  const ago = folder.updatedAt ? timeAgo(folder.updatedAt) : (folder.createdAt ? timeAgo(folder.createdAt) : '');
+  const actionBtns = `
+    <button class="saved-folder-btn" data-action="folder-up" data-folder-id="${folder.id}" title="Move up">${CHEVRON_UP}</button>
+    <button class="saved-folder-btn" data-action="folder-down" data-folder-id="${folder.id}" title="Move down">${CHEVRON_DOWN}</button>
+    <button class="saved-folder-btn" data-action="rename-folder" data-folder-id="${folder.id}" title="Rename">${PENCIL_SVG}</button>
+    <button class="saved-folder-btn danger" data-action="delete-folder" data-folder-id="${folder.id}" title="Delete">${TRASH_SVG}</button>`;
+  const body = items.map(item =>
+    item.kind === 'group'
+      ? renderDeferredGroup(item, storedIcons, liveWorkspaces)
+      : renderDeferredItem(item)
+  ).join('');
+  return `
+    <div class="saved-folder" data-saved-folder-id="${folder.id}">
+      <div class="saved-folder-header" data-action="toggle-saved-folder" data-folder-id="${folder.id}">
+        <svg class="saved-folder-chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"/></svg>
+        <span class="saved-folder-name">${escHtml(folder.name)}</span>
+        <div class="saved-folder-meta">
+          <span>${items.length}</span>
+          ${ago ? `<span>· ${ago}</span>` : ''}
+        </div>
+        <div class="saved-folder-actions">${actionBtns}</div>
+      </div>
+      <div class="saved-folder-body">${body}</div>
+    </div>`;
+}
+
+/* ----------------------------------------------------------------
+   FOLDER BAR — horizontal chip strip + management panel
+   ---------------------------------------------------------------- */
+
+const ADD_FOLDER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/></svg>`;
+const GEAR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94H9.75c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"/></svg>`;
+
+function renderFolderBar(folders) {
+  const wrap = document.getElementById('folderBarWrap');
+  const bar  = document.getElementById('folderBar');
+  if (!bar || !wrap) return;
+
+  if (folders.length === 0) {
+    wrap.style.display = 'none';
+    return;
+  }
+
+  wrap.style.display = 'block';
+
+  const allActive = !activeFolderId ? ' active' : '';
+  let html = `<button class="folder-chip${allActive}" data-action="filter-folder" data-folder-id="">All</button>`;
+
+  for (const f of folders) {
+    const isActive = activeFolderId === f.id;
+    html += `<button class="folder-chip${isActive ? ' active' : ''}" data-action="filter-folder" data-folder-id="${escHtml(f.id)}">
+      ${FOLDER_SVG}<span class="folder-chip-name">${escHtml(f.name)}</span>
+    </button>`;
+  }
+
+  html += `<span class="folder-bar-spacer"></span>`;
+  html += `<button class="folder-chip-new" data-action="new-folder-bar" title="Create new folder">${ADD_FOLDER_SVG}New folder</button>`;
+  html += `<button class="folder-manage-toggle${_folderManagePanelOpen ? ' open' : ''}" data-action="toggle-folder-manage" title="Manage folders">${GEAR_SVG}Manage</button>`;
+
+  bar.innerHTML = html;
+}
+
+function renderFolderManagePanel(folders) {
+  const panel = document.getElementById('folderManagePanel');
+  if (!panel) return;
+
+  if (!_folderManagePanelOpen || folders.length === 0) {
+    panel.style.display = 'none';
+    return;
+  }
+
+  panel.style.display = 'block';
+  let html = `<div class="folder-manage-list">`;
+  for (const f of folders) {
+    html += `<div class="folder-manage-row" data-folder-id="${escHtml(f.id)}">
+      <span class="folder-manage-icon">${FOLDER_SVG}</span>
+      <span class="folder-manage-name">${escHtml(f.name)}</span>
+      <div class="folder-manage-btns">
+        <button data-action="folder-up"     data-folder-id="${escHtml(f.id)}" title="Move up">${CHEVRON_UP}</button>
+        <button data-action="folder-down"   data-folder-id="${escHtml(f.id)}" title="Move down">${CHEVRON_DOWN}</button>
+        <button data-action="rename-folder" data-folder-id="${escHtml(f.id)}" title="Rename">${PENCIL_SVG}</button>
+        <button class="danger" data-action="delete-folder" data-folder-id="${escHtml(f.id)}" title="Delete">${TRASH_SVG}</button>
+      </div>
+    </div>`;
+  }
+  html += `</div>`;
+  panel.innerHTML = html;
 }
 
 async function renderStaticDashboard() {
@@ -1651,8 +2036,25 @@ async function renderStaticDashboard() {
     }
   }
 
-  // Sort by tab count descending — busiest domain first
-  domainGroups = Object.values(groupMap).sort((a, b) => b.tabs.length - a.tabs.length);
+  // Sort by tab count descending — busiest domain first; alphabetical tiebreaker
+  // keeps equal-count groups in a stable order across re-renders.
+  domainGroups = Object.values(groupMap).sort((a, b) => {
+    const diff = b.tabs.length - a.tabs.length;
+    return diff !== 0 ? diff : a.domain.localeCompare(b.domain);
+  });
+
+  // --- Load folder data (needed for bar + card rendering) ---
+  const [folders, dfMapRaw, { domainFolderOrder = {} }] = await Promise.all([
+    getFolders(),
+    chrome.storage.local.get('domainFolderMap'),
+    chrome.storage.local.get('domainFolderOrder'),
+  ]);
+  const dfMap = dfMapRaw.domainFolderMap || {};
+  _domainFolderMap = dfMap;
+
+  // Render global folder bar + management panel
+  renderFolderBar(folders);
+  renderFolderManagePanel(folders);
 
   // --- Render domain cards ---
   const openTabsSection      = document.getElementById('openTabsSection');
@@ -1667,7 +2069,7 @@ async function renderStaticDashboard() {
     openTabsSectionCount.textContent =
       `${dCount} domain${dCount !== 1 ? 's' : ''} · ${tCount} tab${tCount !== 1 ? 's' : ''}`;
     const playFlip = flipDomainCards(openTabsMissionsEl);
-    openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
+    openTabsMissionsEl.innerHTML = renderOpenTabsWithFolders(folders, dfMap, domainFolderOrder);
     playFlip();
     openTabsSection.style.display = 'block';
   } else if (openTabsSection) {
@@ -1792,6 +2194,7 @@ document.addEventListener('click', async (e) => {
     const tabUrl = actionEl.dataset.tabUrl;
     if (!tabUrl) return;
 
+    suppressAutoRefresh();
     // Close the tab in Chrome directly
     const allTabs = await chrome.tabs.query({});
     const match   = allTabs.find(t => t.url === tabUrl);
@@ -1833,6 +2236,7 @@ document.addEventListener('click', async (e) => {
     const tabTitle = actionEl.dataset.tabTitle || tabUrl;
     if (!tabUrl) return;
 
+    suppressAutoRefresh();
     // Find the source tab so we can remember its Opera GX workspace + position
     const sourceTab = openTabs.find(t => t.url === tabUrl);
 
@@ -1960,6 +2364,7 @@ document.addEventListener('click', async (e) => {
 
   // ---- Save the whole domain group for later (active checklist) ----
   if (action === 'save-domain-group' || action === 'archive-domain-group') {
+    suppressAutoRefresh();
     const directToArchive = action === 'archive-domain-group';
     const domainId = actionEl.dataset.domainId;
     const group    = domainGroups.find(g =>
@@ -2241,6 +2646,7 @@ document.addEventListener('click', async (e) => {
 
   // ---- Close all tabs in a domain group ----
   if (action === 'close-domain-tabs') {
+    suppressAutoRefresh();
     const domainId = actionEl.dataset.domainId;
     const group    = domainGroups.find(g => {
       return 'domain-' + g.domain.replace(/[^a-z0-9]/g, '-') === domainId;
@@ -2324,6 +2730,245 @@ document.addEventListener('click', (e) => {
   }
 });
 
+/* ----------------------------------------------------------------
+   FOLDER ACTION HANDLERS — new-folder, rename, delete, reorder,
+   toggle-collapse, move-to-folder, deferred/domain reorder
+   ---------------------------------------------------------------- */
+
+document.addEventListener('click', async (e) => {
+  const a = e.target.closest('[data-action]');
+  if (!a) return;
+  const act = a.dataset.action;
+
+  // ---- Filter by folder (folder bar chip click) ----
+  if (act === 'filter-folder') {
+    const fid = a.dataset.folderId || null;
+    if (activeFolderId === fid) return;
+    activeFolderId = fid;
+    await Promise.all([renderStaticDashboard(), renderDeferredColumn()]);
+    return;
+  }
+
+  // ---- Create new folder from the folder bar ----
+  if (act === 'new-folder-bar') {
+    const folder = await createFolder('New Folder');
+    activeFolderId = folder.id;
+    _folderManagePanelOpen = true;
+    await Promise.all([renderStaticDashboard(), renderDeferredColumn()]);
+    // Start rename immediately in the manage panel
+    const nameEl = document.querySelector(`.folder-manage-row[data-folder-id="${folder.id}"] .folder-manage-name`);
+    if (nameEl) startFolderRename(nameEl, folder.id);
+    return;
+  }
+
+  // ---- Toggle folder management panel ----
+  if (act === 'toggle-folder-manage') {
+    _folderManagePanelOpen = !_folderManagePanelOpen;
+    const folders = await getFolders();
+    renderFolderManagePanel(folders);
+    document.querySelectorAll('[data-action="toggle-folder-manage"]')
+      .forEach(btn => btn.classList.toggle('open', _folderManagePanelOpen));
+    return;
+  }
+
+  // ---- Create new folder (section-level button) ----
+  if (act === 'new-folder') {
+    const section = a.dataset.section; // "open" or "saved"
+    const folder = await createFolder('New Folder');
+    if (section === 'open') {
+      await renderStaticDashboard();
+    } else {
+      await renderDeferredColumn();
+    }
+    // Immediately start renaming it
+    const nameEl = document.querySelector(`[data-folder-id="${folder.id}"] .tab-folder-name, [data-saved-folder-id="${folder.id}"] .saved-folder-name`);
+    if (nameEl) startFolderRename(nameEl, folder.id);
+    return;
+  }
+
+  // ---- Toggle open-tabs folder collapse ----
+  if (act === 'toggle-tab-folder') {
+    e.stopPropagation();
+    const folderId = a.dataset.folderId;
+    a.classList.toggle('collapsed');
+    const collapsed = a.classList.contains('collapsed');
+    document.querySelectorAll(`.mission-card[data-folder-id="${folderId}"]`)
+      .forEach(c => c.classList.toggle('folder-hidden', collapsed));
+    return;
+  }
+
+  // ---- Toggle saved-column folder collapse ----
+  if (act === 'toggle-saved-folder') {
+    e.stopPropagation();
+    const folder = a.closest('.saved-folder');
+    if (folder) folder.classList.toggle('collapsed');
+    return;
+  }
+
+  // ---- Rename folder ----
+  if (act === 'rename-folder') {
+    e.stopPropagation();
+    const folderId = a.dataset.folderId;
+    const nameEl = document.querySelector(
+      `.folder-manage-row[data-folder-id="${folderId}"] .folder-manage-name,
+       [data-action="toggle-tab-folder"][data-folder-id="${folderId}"] .tab-folder-name,
+       [data-action="toggle-saved-folder"][data-folder-id="${folderId}"] .saved-folder-name`
+    );
+    if (nameEl) startFolderRename(nameEl, folderId);
+    return;
+  }
+
+  // ---- Delete folder ----
+  if (act === 'delete-folder') {
+    e.stopPropagation();
+    const folderId = a.dataset.folderId;
+    if (activeFolderId === folderId) activeFolderId = null;
+    await deleteFolder(folderId);
+    await Promise.all([renderStaticDashboard(), renderDeferredColumn()]);
+    showToast('Folder deleted — items moved to unfiled');
+    return;
+  }
+
+  // ---- Reorder folder up / down ----
+  if (act === 'folder-up' || act === 'folder-down') {
+    e.stopPropagation();
+    const folderId = a.dataset.folderId;
+    await moveFolderOrder(folderId, act === 'folder-up' ? 'up' : 'down');
+    await Promise.all([renderStaticDashboard(), renderDeferredColumn()]);
+    return;
+  }
+
+  // ---- Move domain card to folder (show picker) ----
+  if (act === 'move-domain-to-folder') {
+    e.stopPropagation();
+    const domain    = a.dataset.domain;
+    const currentFo = a.dataset.currentFolder || null;
+    const folders   = await getFolders();
+    showFolderPicker(a, folders, currentFo, async (folderId) => {
+      await setDomainFolder(domain, folderId);
+      await renderStaticDashboard();
+    });
+    return;
+  }
+
+  // ---- Move saved item to folder (show picker) ----
+  if (act === 'move-saved-to-folder') {
+    e.stopPropagation();
+    const itemId    = a.dataset.deferredId;
+    const currentFo = a.dataset.currentFolder || null;
+    const folders   = await getFolders();
+    showFolderPicker(a, folders, currentFo, async (folderId) => {
+      await setDeferredFolder(itemId, folderId);
+      await renderDeferredColumn();
+    });
+    return;
+  }
+
+  // ---- Reorder saved item up / down ----
+  if (act === 'deferred-up' || act === 'deferred-down') {
+    e.stopPropagation();
+    const itemId = a.dataset.deferredId;
+    await reorderDeferredItem(itemId, act === 'deferred-up' ? 'up' : 'down');
+    await renderDeferredColumn();
+    return;
+  }
+
+  // ---- Reorder domain card up / down ----
+  if (act === 'domain-up' || act === 'domain-down') {
+    e.stopPropagation();
+    const domain   = a.dataset.domain;
+    const folderId = a.dataset.folderId || null;
+    await reorderDomainCard(domain, act === 'domain-up' ? 'up' : 'down', folderId || null);
+    await renderStaticDashboard();
+    return;
+  }
+});
+
+// ---- Folder picker: close on outside click ----
+document.addEventListener('click', (e) => {
+  if (!e.target.closest('.folder-picker')) closeFolderPicker();
+});
+
+/* ----------------------------------------------------------------
+   FOLDER PICKER HELPER
+   ---------------------------------------------------------------- */
+
+let _folderPickerCallback = null;
+
+function showFolderPicker(anchor, folders, currentFolderId, onSelect) {
+  closeFolderPicker();
+  _folderPickerCallback = onSelect;
+
+  const picker = document.createElement('div');
+  picker.className = 'folder-picker';
+  picker.id = 'folderPicker';
+
+  const noFolderCls = !currentFolderId ? ' current' : '';
+  picker.innerHTML = `
+    <button class="folder-picker-item${noFolderCls}" data-pick-folder="">
+      <svg width="13" height="13" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/></svg>
+      No folder (unfiled)
+    </button>
+    ${folders.length ? '<div class="folder-picker-sep"></div>' : ''}
+    ${folders.map(f => {
+      const cls = f.id === currentFolderId ? ' current' : '';
+      return `<button class="folder-picker-item${cls}" data-pick-folder="${f.id}">
+        ${FOLDER_SVG} ${escHtml(f.name)}
+      </button>`;
+    }).join('')}`;
+
+  document.body.appendChild(picker);
+
+  const rect = anchor.getBoundingClientRect();
+  picker.style.top  = (rect.bottom + window.scrollY + 4) + 'px';
+  picker.style.left = (rect.left  + window.scrollX)     + 'px';
+
+  picker.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-pick-folder]');
+    if (!btn) return;
+    const fid = btn.dataset.pickFolder || null;
+    closeFolderPicker();
+    if (_folderPickerCallback) await _folderPickerCallback(fid);
+    _folderPickerCallback = null;
+  });
+}
+
+function closeFolderPicker() {
+  document.getElementById('folderPicker')?.remove();
+}
+
+/* ----------------------------------------------------------------
+   FOLDER NAME INLINE EDIT
+   ---------------------------------------------------------------- */
+
+function startFolderRename(nameEl, folderId) {
+  const oldName  = nameEl.textContent.trim();
+  const isTab    = nameEl.classList.contains('tab-folder-name');
+  const isManage = nameEl.classList.contains('folder-manage-name');
+  const cls      = isTab ? 'tab-folder-name-input' : isManage ? 'folder-manage-name-input' : 'saved-folder-name-input';
+
+  const input = document.createElement('input');
+  input.className = cls;
+  input.value     = oldName;
+  nameEl.replaceWith(input);
+  input.focus();
+  input.select();
+
+  async function save() {
+    const newName = input.value.trim() || oldName;
+    const folders = await getFolders();
+    const f = folders.find(x => x.id === folderId);
+    if (f) { f.name = newName; f.updatedAt = Date.now(); await saveFolders(folders); }
+    await Promise.all([renderStaticDashboard(), renderDeferredColumn()]);
+  }
+
+  input.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter')  { e.preventDefault(); save(); }
+    if (e.key === 'Escape') { input.value = oldName; save(); }
+  });
+  input.addEventListener('blur', save);
+}
+
 // ---- Icon picker: click-outside closes it, Escape closes it ----
 document.addEventListener('click', (e) => {
   const picker = document.getElementById('iconPicker');
@@ -2335,8 +2980,128 @@ document.addEventListener('click', (e) => {
 
 document.addEventListener('keydown', (e) => {
   if (e.key !== 'Escape') return;
+  closeFolderPicker();
   const picker = document.getElementById('iconPicker');
   if (picker && picker.style.display !== 'none') closeIconPicker();
+});
+
+/* ----------------------------------------------------------------
+   DRAG-AND-DROP — move domain cards and saved items into folders
+   ---------------------------------------------------------------- */
+
+(function initDragAndDrop() {
+  // Domain cards → open-tabs folder headers
+  document.addEventListener('dragstart', (e) => {
+    const card = e.target.closest('.mission-card[data-domain]');
+    if (card) {
+      e.dataTransfer.setData('text/plain', JSON.stringify({ type: 'domain', domain: card.dataset.domain }));
+      e.dataTransfer.effectAllowed = 'move';
+      return;
+    }
+    const item = e.target.closest('.deferred-item[data-deferred-id], .deferred-group[data-group-id]');
+    if (item) {
+      const id = item.dataset.deferredId || item.dataset.groupId;
+      e.dataTransfer.setData('text/plain', JSON.stringify({ type: 'deferred', id }));
+      e.dataTransfer.effectAllowed = 'move';
+    }
+  });
+
+  document.addEventListener('dragover', (e) => {
+    const tabHeader   = e.target.closest('.tab-folder-header-card');
+    const savedHeader = e.target.closest('.saved-folder-header');
+    const target = tabHeader || savedHeader;
+    if (!target) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    target.classList.add('drop-target');
+  });
+
+  document.addEventListener('dragleave', (e) => {
+    const target = e.target.closest('.tab-folder-header-card, .saved-folder-header');
+    if (target) target.classList.remove('drop-target');
+  });
+
+  document.addEventListener('drop', async (e) => {
+    const tabHeader   = e.target.closest('.tab-folder-header-card');
+    const savedHeader = e.target.closest('.saved-folder-header');
+    const target = tabHeader || savedHeader;
+    if (!target) return;
+    target.classList.remove('drop-target');
+    e.preventDefault();
+    try {
+      const data = JSON.parse(e.dataTransfer.getData('text/plain'));
+      const folderId = target.dataset.folderId;
+      if (data.type === 'domain' && tabHeader) {
+        await setDomainFolder(data.domain, folderId);
+        await renderStaticDashboard();
+      } else if (data.type === 'deferred' && savedHeader) {
+        await setDeferredFolder(data.id, folderId);
+        await renderDeferredColumn();
+      }
+    } catch {}
+  });
+})();
+
+/* ----------------------------------------------------------------
+   GLOBAL SEARCH — filters both columns in real time
+   ---------------------------------------------------------------- */
+
+function applySearch(query) {
+  const q = query.toLowerCase().trim();
+  const wrap = document.getElementById('searchBarWrap');
+  if (wrap) wrap.classList.toggle('has-query', q.length > 0);
+
+  // Filter open-tab domain cards
+  document.querySelectorAll('.mission-card[data-domain]').forEach(card => {
+    const domain = (card.dataset.domain || '').toLowerCase();
+    const titles = Array.from(card.querySelectorAll('.chip-text'))
+      .map(el => el.textContent.toLowerCase()).join(' ');
+    card.style.display = (!q || domain.includes(q) || titles.includes(q)) ? '' : 'none';
+  });
+
+  // Show/hide folder headers based on whether they have visible cards
+  document.querySelectorAll('.tab-folder-header-card[data-folder-id]').forEach(header => {
+    if (!q) { header.style.display = ''; return; }
+    const fid = header.dataset.folderId;
+    const anyVisible = Array.from(
+      document.querySelectorAll(`.mission-card[data-folder-id="${fid}"]`)
+    ).some(c => c.style.display !== 'none');
+    header.style.display = anyVisible ? '' : 'none';
+  });
+
+  // Filter saved items
+  document.querySelectorAll('.deferred-item[data-deferred-id]').forEach(item => {
+    const title  = (item.querySelector('.deferred-title')?.textContent || '').toLowerCase();
+    const domain = (item.querySelector('.deferred-meta span')?.textContent || '').toLowerCase();
+    item.style.display = (!q || title.includes(q) || domain.includes(q)) ? '' : 'none';
+  });
+
+  document.querySelectorAll('.deferred-group[data-group-id]').forEach(group => {
+    const label = (group.querySelector('.group-header-label')?.textContent || '').toLowerCase();
+    const texts = Array.from(group.querySelectorAll('.group-item-text'))
+      .map(el => el.textContent.toLowerCase()).join(' ');
+    group.style.display = (!q || label.includes(q) || texts.includes(q)) ? '' : 'none';
+  });
+
+  // Show/hide saved folder wrappers
+  document.querySelectorAll('.saved-folder[data-saved-folder-id]').forEach(sf => {
+    if (!q) { sf.style.display = ''; return; }
+    const anyVisible = Array.from(
+      sf.querySelectorAll('.deferred-item, .deferred-group')
+    ).some(el => el.style.display !== 'none');
+    sf.style.display = anyVisible ? '' : 'none';
+  });
+}
+
+document.addEventListener('input', (e) => {
+  if (e.target.id === 'searchBar') applySearch(e.target.value);
+});
+
+document.addEventListener('click', (e) => {
+  if (e.target.closest('#searchClearBtn')) {
+    const bar = document.getElementById('searchBar');
+    if (bar) { bar.value = ''; applySearch(''); }
+  }
 });
 
 // ---- Icon picker: free-form input (accepts any emoji / paste / Win+.) ----
@@ -2502,7 +3267,19 @@ document.addEventListener('error', (e) => {
    ---------------------------------------------------------------- */
 
 let __renderDebounceTimer = null;
+let __autoRefreshSuppressed = false;
+let __autoRefreshSuppressTimer = null;
+
+function suppressAutoRefresh(ms = 1200) {
+  __autoRefreshSuppressed = true;
+  clearTimeout(__autoRefreshSuppressTimer);
+  __autoRefreshSuppressTimer = setTimeout(() => {
+    __autoRefreshSuppressed = false;
+  }, ms);
+}
+
 function scheduleDashboardRefresh(delay = 400) {
+  if (__autoRefreshSuppressed) return;
   if (__renderDebounceTimer) clearTimeout(__renderDebounceTimer);
   __renderDebounceTimer = setTimeout(() => {
     __renderDebounceTimer = null;

--- a/extension/app.js
+++ b/extension/app.js
@@ -895,7 +895,7 @@ const ICONS = {
   tabs:    `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 8.25V18a2.25 2.25 0 0 0 2.25 2.25h13.5A2.25 2.25 0 0 0 21 18V8.25m-18 0V6a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 6v2.25m-18 0h18" /></svg>`,
   close:   `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>`,
   archive: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5m6 4.125l2.25 2.25m0 0l2.25 2.25M12 13.875l2.25-2.25M12 13.875l-2.25 2.25M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>`,
-  focus:   `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>`,
+  focus:   `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>`,
 };
 
 
@@ -1217,7 +1217,7 @@ function renderDeferredItem(item) {
         </div>
       </div>
       <button class="deferred-restore" data-action="restore-deferred" data-deferred-id="${item.id}" title="Reopen as a tab">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
       </button>
       <button class="deferred-dismiss" data-action="dismiss-deferred" data-deferred-id="${item.id}" title="Dismiss">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
@@ -1329,7 +1329,7 @@ function renderDeferredGroup(group, storedIcons = {}, liveWorkspaces = new Map()
           <span class="group-item-text">${item.title || item.url}</span>
         </a>
         <button class="deferred-restore" data-action="restore-group-item" data-group-id="${group.id}" data-item-id="${item.id}" title="Reopen as a tab">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
         </button>
         <button class="deferred-dismiss" data-action="dismiss-group-item" data-group-id="${group.id}" data-item-id="${item.id}" title="Dismiss">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
@@ -1352,7 +1352,7 @@ function renderDeferredGroup(group, storedIcons = {}, liveWorkspaces = new Map()
           <div class="group-header-meta">${metaHtml}</div>
         </div>
         <button class="group-header-action" data-action="restore-group-all" data-group-id="${group.id}" title="Reopen all tabs">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
         </button>
         <button class="group-header-action group-check" data-action="check-group" data-group-id="${group.id}" title="Archive this group">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>
@@ -1398,7 +1398,7 @@ function renderArchiveGroup(group, storedIcons = {}, liveWorkspaces = new Map())
           <span class="group-item-text">${item.title || item.url}</span>
         </a>
         <button class="deferred-restore" data-action="restore-group-item" data-group-id="${group.id}" data-item-id="${item.id}" title="Reopen as a tab">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
         </button>
         <button class="deferred-dismiss" data-action="dismiss-group-item" data-group-id="${group.id}" data-item-id="${item.id}" title="Dismiss">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
@@ -1421,7 +1421,7 @@ function renderArchiveGroup(group, storedIcons = {}, liveWorkspaces = new Map())
           <div class="group-header-meta">${metaHtml}</div>
         </div>
         <button class="group-header-action" data-action="restore-group-all" data-group-id="${group.id}" title="Reopen all tabs">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
         </button>
         <button class="group-header-action" data-action="restore-archived-group" data-group-id="${group.id}" title="Move back to Saved for Later">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" /></svg>

--- a/extension/app.js
+++ b/extension/app.js
@@ -40,13 +40,19 @@ async function fetchOpenTabs() {
 
     const tabs = await chrome.tabs.query({});
     openTabs = tabs.map(t => ({
-      id:       t.id,
-      url:      t.url,
-      title:    t.title,
-      windowId: t.windowId,
-      active:   t.active,
+      id:            t.id,
+      url:           t.url,
+      title:         t.title,
+      windowId:      t.windowId,
+      active:        t.active,
+      index:         t.index,   // position in the tab strip — used for workspace ordering & tab-restore
+      // Opera GX exposes these; other Chromium browsers leave them undefined.
+      // No icon field is exposed — workspace icons come from chrome.storage.local
+      // and are managed via the in-UI emoji picker (the pencil on each pill).
+      workspaceId:   t.workspaceId,
+      workspaceName: t.workspaceName,
       // Flag Tab Out's own pages so we can detect duplicate new tabs
-      isTabOut: t.url === newtabUrl || t.url === 'chrome://newtab/',
+      isTabOut:      t.url === newtabUrl || t.url === 'chrome://newtab/',
     }));
   } catch {
     // chrome.tabs API unavailable (shouldn't happen in an extension page)
@@ -228,12 +234,20 @@ async function closeTabOutDupes() {
 async function saveTabForLater(tab) {
   const { deferred = [] } = await chrome.storage.local.get('deferred');
   deferred.push({
-    id:        Date.now().toString(),
-    url:       tab.url,
-    title:     tab.title,
-    savedAt:   new Date().toISOString(),
-    completed: false,
-    dismissed: false,
+    id:            Date.now().toString(),
+    url:           tab.url,
+    title:         tab.title,
+    // Remember the Opera GX workspace so restore can put it back where it came
+    // from. Older entries lack this and will restore into the active workspace.
+    workspaceId:   tab.workspaceId   || null,
+    workspaceName: tab.workspaceName || null,
+    // Remember the original tab strip position too — restore will try to put
+    // the tab back at this index (clamped to current tab count by Chrome).
+    index:         (typeof tab.index === 'number') ? tab.index : null,
+    windowId:      tab.windowId || null,
+    savedAt:       new Date().toISOString(),
+    completed:     false,
+    dismissed:     false,
   });
   await chrome.storage.local.set({ deferred });
 }
@@ -281,6 +295,219 @@ async function dismissSavedTab(id) {
     tab.dismissed = true;
     await chrome.storage.local.set({ deferred });
   }
+}
+
+/**
+ * restoreArchivedTab(id)
+ *
+ * Moves an archived (completed) tab back to the active "Saved for Later" list.
+ */
+async function restoreArchivedTab(id) {
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  const tab = deferred.find(t => t.id === id);
+  if (tab) {
+    tab.completed = false;
+    delete tab.completedAt;
+    await chrome.storage.local.set({ deferred });
+  }
+}
+
+
+/* ----------------------------------------------------------------
+   GROUPED DEFERRED ENTRIES
+
+   In addition to individual tabs, the 'deferred' storage array can
+   also hold "group" entries that bundle multiple tabs saved together
+   from a single domain card. Shape:
+
+     {
+       id, kind: 'group',
+       label, domain,                 // for rendering (favicon lookup etc.)
+       savedAt, completedAt?,
+       completed, dismissed,          // same lifecycle flags as tabs
+       items: [
+         { id, url, title,
+           workspaceId, workspaceName, index, windowId,
+           dismissed }                // per-item flag; group is auto-dismissed
+                                      //   when every item is dismissed
+       ]
+     }
+
+   Legacy individual entries have no `kind` field and are treated as
+   kind: 'tab' by the renderer.
+   ---------------------------------------------------------------- */
+
+/**
+ * saveGroupForLater(group, { directToArchive })
+ *
+ * Persists a whole domain group (all tabs + per-tab restore metadata)
+ * as a single grouped entry in chrome.storage.local.
+ */
+async function saveGroupForLater(group, options = {}) {
+  const { directToArchive = false, baseId = Date.now().toString() } = options;
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  const now = new Date().toISOString();
+  const label  = group.label || friendlyDomain(group.domain);
+
+  deferred.push({
+    id:          baseId,
+    kind:        'group',
+    label,
+    domain:      group.domain,
+    savedAt:     now,
+    completed:   !!directToArchive,
+    completedAt: directToArchive ? now : undefined,
+    dismissed:   false,
+    items: (group.tabs || []).map((t, i) => ({
+      id:            `${baseId}-${i}`,
+      url:           t.url,
+      title:         t.title,
+      workspaceId:   t.workspaceId   || null,
+      workspaceName: t.workspaceName || null,
+      index:         (typeof t.index === 'number') ? t.index : null,
+      windowId:      t.windowId      || null,
+      dismissed:     false,
+    })),
+  });
+
+  await chrome.storage.local.set({ deferred });
+}
+
+/**
+ * dismissGroupItem(groupId, itemId)
+ *
+ * Removes a single tab from a saved group. If every tab in the group
+ * is now dismissed, the group itself is auto-dismissed too.
+ */
+async function dismissGroupItem(groupId, itemId) {
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  const group = deferred.find(g => g.id === groupId && g.kind === 'group');
+  if (!group) return;
+  const item = group.items.find(i => i.id === itemId);
+  if (!item) return;
+  item.dismissed = true;
+  // Auto-dismiss the group when it's empty
+  if (group.items.every(i => i.dismissed)) group.dismissed = true;
+  await chrome.storage.local.set({ deferred });
+}
+
+/**
+ * checkOffGroup(groupId) — move a saved group to the archive.
+ */
+async function checkOffGroup(groupId) {
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  const group = deferred.find(g => g.id === groupId && g.kind === 'group');
+  if (!group) return;
+  group.completed = true;
+  group.completedAt = new Date().toISOString();
+  await chrome.storage.local.set({ deferred });
+}
+
+/**
+ * dismissGroup(groupId) — permanently remove a saved group.
+ */
+async function dismissGroup(groupId) {
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  const group = deferred.find(g => g.id === groupId && g.kind === 'group');
+  if (!group) return;
+  group.dismissed = true;
+  await chrome.storage.local.set({ deferred });
+}
+
+/**
+ * restoreArchivedGroup(groupId) — move an archived group back to active saved.
+ */
+async function restoreArchivedGroup(groupId) {
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  const group = deferred.find(g => g.id === groupId && g.kind === 'group');
+  if (!group) return;
+  group.completed = false;
+  delete group.completedAt;
+  await chrome.storage.local.set({ deferred });
+}
+
+/**
+ * buildLiveWorkspaceMap()
+ *
+ * Derives a Map<workspaceId, currentWorkspaceName> from the live tab list.
+ * Used to (a) self-heal stored workspace names across renames, and (b) detect
+ * when a workspace has been deleted so we can flag it in the badge.
+ */
+function buildLiveWorkspaceMap() {
+  const map = new Map();
+  for (const t of openTabs) {
+    if (t.workspaceId && t.workspaceName && !map.has(t.workspaceId)) {
+      map.set(t.workspaceId, t.workspaceName);
+    }
+  }
+  return map;
+}
+
+/**
+ * migrateWorkspaceNames(deferred, storedIcons, liveWorkspaces)
+ *
+ * Walks every saved group's items. For any item whose workspaceId is still
+ * live but whose stored workspaceName differs, updates the name in-place and
+ * moves the user's emoji icon (if any) from the old name key to the new name
+ * key in the workspaceIcons map. Returns { itemsChanged, iconsChanged } so the
+ * caller can persist to chrome.storage.local only when something actually
+ * changed (avoids spurious writes on every render).
+ *
+ * Skipped entirely when liveWorkspaces is empty (tabs haven't loaded yet —
+ * mutating based on an empty map would falsely "delete" everything).
+ */
+function migrateWorkspaceNames(deferred, storedIcons, liveWorkspaces) {
+  if (!liveWorkspaces || liveWorkspaces.size === 0) {
+    return { itemsChanged: false, iconsChanged: false };
+  }
+
+  const renames = new Map();  // oldName -> newName
+  let itemsChanged = false;
+
+  for (const entry of deferred) {
+    if (entry.kind !== 'group' || !Array.isArray(entry.items)) continue;
+    for (const item of entry.items) {
+      if (!item.workspaceId) continue;
+      const live = liveWorkspaces.get(item.workspaceId);
+      if (!live) continue;                       // workspace deleted — leave name alone
+      if (item.workspaceName === live) continue; // no change
+      if (item.workspaceName) renames.set(item.workspaceName, live);
+      item.workspaceName = live;
+      itemsChanged = true;
+    }
+  }
+
+  let iconsChanged = false;
+  for (const [oldName, newName] of renames) {
+    if (storedIcons[oldName] && !storedIcons[newName]) {
+      storedIcons[newName] = storedIcons[oldName];
+      delete storedIcons[oldName];
+      iconsChanged = true;
+    }
+  }
+
+  return { itemsChanged, iconsChanged };
+}
+
+
+/* ----------------------------------------------------------------
+   WORKSPACE ICONS — chrome.storage.local
+
+   User-picked workspace emojis live under the 'workspaceIcons' key,
+   keyed by workspace NAME (not id, since ids can shift). The in-UI
+   picker (pencil on each workspace pill) is the only way to manage them.
+   ---------------------------------------------------------------- */
+
+async function getWorkspaceIconOverrides() {
+  const { workspaceIcons = {} } = await chrome.storage.local.get('workspaceIcons');
+  return workspaceIcons;
+}
+
+async function setWorkspaceIconOverride(name, icon) {
+  const overrides = await getWorkspaceIconOverrides();
+  if (icon) overrides[name] = icon;
+  else delete overrides[name];
+  await chrome.storage.local.set({ workspaceIcons: overrides });
 }
 
 
@@ -613,13 +840,9 @@ function capitalize(str) {
 
 function stripTitleNoise(title) {
   if (!title) return '';
-  // Strip leading notification count: "(2) Title"
+  // Strip leading notification count: "(2) Title" — that's a browser/page
+  // unread badge, not part of the actual page name.
   title = title.replace(/^\(\d+\+?\)\s*/, '');
-  // Strip inline counts like "Inbox (16,359)"
-  title = title.replace(/\s*\([\d,]+\+?\)\s*/g, ' ');
-  // Strip email addresses (privacy + cleaner display)
-  title = title.replace(/\s*[\-\u2010-\u2015]\s*[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g, '');
-  title = title.replace(/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g, '');
   // Clean X/Twitter format
   title = title.replace(/\s+on X:\s*/, ': ');
   title = title.replace(/\s*\/\s*X\s*$/, '');
@@ -708,6 +931,26 @@ const ICONS = {
    ---------------------------------------------------------------- */
 let domainGroups = [];
 
+// Opera GX workspace filter — null = "All", otherwise a workspaceId string
+let activeWorkspace = null;
+
+// Curated emoji library used by the workspace icon picker.
+// Grouped by category; the free-form input below accepts anything else.
+const EMOJI_CATEGORIES = [
+  { name: 'Work',    emojis: ['💼','📊','📈','📉','💻','🖥️','⌨️','🖨️','📱','📞','✉️','📧','📫','📎','📌','📍','🗂️','📁','📂','📋','📝','✏️','🖊️','📅','📆','🗓️','⏰','⏱️','🔖','💡'] },
+  { name: 'Money',   emojis: ['💰','💵','💳','💎','🏦','💹','🧾','🪙'] },
+  { name: 'Food',    emojis: ['🍳','🍽️','🍔','🍕','🥗','🍜','🍣','🍱','🥟','🍰','🎂','☕','🍵','🍷','🍺','🥤','🍎','🥐','🍪','🌮','🍿','🥞','🧇','🥙','🥘','🧃'] },
+  { name: 'Nature',  emojis: ['🌿','🌱','🌳','🌺','🌸','🌻','🌞','🌙','⭐','🌈','☀️','🔥','💧','🌊','🏔️','⛰️','🏝️','🏖️','🌍','🌵','🍄'] },
+  { name: 'Travel',  emojis: ['✈️','🚗','🚕','🚂','🚢','⚓','🚀','🏍️','🚲','🛫','🗺️','🏨','🛣️'] },
+  { name: 'Home',    emojis: ['🏠','🏡','🛋️','🛏️','🚪','🧹','🧺','📦','🎁','🔑','🔒','🔨','🛠️','🔧','⚙️','🧰','🧲','🧼','🪑'] },
+  { name: 'Play',    emojis: ['🎮','🎨','🎵','🎸','🎹','🎧','📷','🎬','📚','📖','🎯','🎲','🧩','🪁','🎭','🎪','🕹️','🎤'] },
+  { name: 'Sport',   emojis: ['🧘','🏃','🚴','🏊','⚽','🏀','🏈','🏐','🎾','🏓','🥊','🥋','🏆','🥇','🏅','⛷️','🏂','🏋️','🤸'] },
+  { name: 'Animals', emojis: ['🐶','🐱','🐭','🐰','🦊','🐻','🐼','🐨','🐯','🦁','🐷','🐸','🐵','🐔','🦆','🐦','🐧','🐢','🐟','🐳','🦋','🐝','🐙','🦉','🦖'] },
+  { name: 'People',  emojis: ['👤','👥','🧠','👁️','👋','👍','👎','✌️','🤝','💪','🫶','🧑‍💻','🧑‍🍳','🧑‍🎨','🧑‍🔬','🧑‍🏫','🧑‍⚕️','🧑‍🔧','🧑‍💼','🧑‍🌾'] },
+  { name: 'Heart',   emojis: ['❤️','🧡','💛','💚','💙','💜','🖤','🤍','🤎','💖','💗','💘','💝','💓','💔'] },
+  { name: 'Symbol',  emojis: ['✨','💫','⭐','🌟','💥','🔥','⚡','💯','✅','🎉','🎊','❓','❗','💬','🔔','🔕','🎫','🏷️','🔱','♾️','🚧','⚠️','☑️','🆕','🆗','🆒','🔸','🔹','🟢','🟡','🔴','🟣','🟠','⚫','⚪'] },
+];
+
 
 /* ----------------------------------------------------------------
    HELPER: filter out browser-internal pages
@@ -759,7 +1002,9 @@ function checkTabOutDupes() {
 
 function buildOverflowChips(hiddenTabs, urlCounts = {}) {
   const hiddenChips = hiddenTabs.map(tab => {
-    const label    = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), '');
+    let tabHostname = '';
+    try { tabHostname = new URL(tab.url).hostname; } catch {}
+    const label    = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), tabHostname);
     const count    = urlCounts[tab.url] || 1;
     const dupeTag  = count > 1 ? ` <span class="chip-dupe-badge">(${count}x)</span>` : '';
     const chipClass = count > 1 ? ' chip-has-dupes' : '';
@@ -769,7 +1014,7 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
     try { domain = new URL(tab.url).hostname; } catch {}
     const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="">` : ''}
       <span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
@@ -803,7 +1048,6 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
 function renderDomainCard(group) {
   const tabs      = group.tabs || [];
   const tabCount  = tabs.length;
-  const isLanding = group.domain === '__landing-pages__';
   const stableId  = 'domain-' + group.domain.replace(/[^a-z0-9]/g, '-');
 
   // Count duplicates (exact URL match)
@@ -835,7 +1079,11 @@ function renderDomainCard(group) {
   const extraCount  = uniqueTabs.length - visibleTabs.length;
 
   const pageChips = visibleTabs.map(tab => {
-    let label = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), group.domain);
+    // Prefer the tab's own hostname for trailing-site-name stripping
+    // (e.g. custom groups use a synthetic key as group.domain).
+    let chipHostname = group.domain;
+    try { chipHostname = new URL(tab.url).hostname; } catch {}
+    let label = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), chipHostname);
     // For localhost tabs, prepend port number so you can tell projects apart
     try {
       const parsed = new URL(tab.url);
@@ -850,7 +1098,7 @@ function renderDomainCard(group) {
     try { domain = new URL(tab.url).hostname; } catch {}
     const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="">` : ''}
       <span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
@@ -863,7 +1111,17 @@ function renderDomainCard(group) {
     </div>`;
   }).join('') + (extraCount > 0 ? buildOverflowChips(uniqueTabs.slice(8), urlCounts) : '');
 
+  const saveIconSvg = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>`;
+
   let actionsHtml = `
+    <button class="action-btn save-tabs" data-action="save-domain-group" data-domain-id="${stableId}" title="Save all tabs to Saved for Later">
+      ${saveIconSvg}
+      Save
+    </button>
+    <button class="action-btn" data-action="archive-domain-group" data-domain-id="${stableId}" title="Archive all tabs (skip the checklist)">
+      ${ICONS.archive}
+      Archive
+    </button>
     <button class="action-btn close-tabs" data-action="close-domain-tabs" data-domain-id="${stableId}">
       ${ICONS.close}
       Close all ${tabCount} tab${tabCount !== 1 ? 's' : ''}
@@ -882,7 +1140,7 @@ function renderDomainCard(group) {
       <div class="status-bar"></div>
       <div class="mission-content">
         <div class="mission-top">
-          <span class="mission-name">${isLanding ? 'Homepages' : (group.label || friendlyDomain(group.domain))}</span>
+          <span class="mission-name">${group.label || friendlyDomain(group.domain)}</span>
           ${tabBadge}
           ${dupeBadge}
         </div>
@@ -920,7 +1178,23 @@ async function renderDeferredColumn() {
   if (!column) return;
 
   try {
-    const { active, archived } = await getSavedTabs();
+    // Read the raw deferred list so we can mutate + persist migrations.
+    const { deferred = [] } = await chrome.storage.local.get('deferred');
+    const storedIcons    = await getWorkspaceIconOverrides();
+    const liveWorkspaces = buildLiveWorkspaceMap();
+
+    // Self-heal: if a workspace was renamed, update every saved group's
+    // stored name and migrate the emoji icon key. Writes back only when
+    // something actually changed.
+    const { itemsChanged, iconsChanged } =
+      migrateWorkspaceNames(deferred, storedIcons, liveWorkspaces);
+    if (itemsChanged) await chrome.storage.local.set({ deferred });
+    if (iconsChanged) await chrome.storage.local.set({ workspaceIcons: storedIcons });
+
+    // Derive visible subsets AFTER migration so render sees fresh names.
+    const visible  = deferred.filter(t => !t.dismissed);
+    const active   = visible.filter(t => !t.completed);
+    const archived = visible.filter(t => t.completed);
 
     // Hide the entire column if there's nothing to show
     if (active.length === 0 && archived.length === 0) {
@@ -930,10 +1204,14 @@ async function renderDeferredColumn() {
 
     column.style.display = 'block';
 
-    // Render active checklist items
+    // Render active checklist items (mix of individual tabs and saved groups)
     if (active.length > 0) {
       countEl.textContent = `${active.length} item${active.length !== 1 ? 's' : ''}`;
-      list.innerHTML = active.map(item => renderDeferredItem(item)).join('');
+      list.innerHTML = active
+        .map(item => item.kind === 'group'
+          ? renderDeferredGroup(item, storedIcons, liveWorkspaces)
+          : renderDeferredItem(item))
+        .join('');
       list.style.display = 'block';
       empty.style.display = 'none';
     } else {
@@ -942,10 +1220,14 @@ async function renderDeferredColumn() {
       empty.style.display = 'block';
     }
 
-    // Render archive section
+    // Render archive section (mix of individual tabs and archived groups)
     if (archived.length > 0) {
       archiveCountEl.textContent = `(${archived.length})`;
-      archiveList.innerHTML = archived.map(item => renderArchiveItem(item)).join('');
+      archiveList.innerHTML = archived
+        .map(item => item.kind === 'group'
+          ? renderArchiveGroup(item, storedIcons, liveWorkspaces)
+          : renderArchiveItem(item))
+        .join('');
       archiveEl.style.display = 'block';
     } else {
       archiveEl.style.display = 'none';
@@ -974,13 +1256,16 @@ function renderDeferredItem(item) {
       <input type="checkbox" class="deferred-checkbox" data-action="check-deferred" data-deferred-id="${item.id}">
       <div class="deferred-info">
         <a href="${item.url}" target="_blank" rel="noopener" class="deferred-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
-          <img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px" onerror="this.style.display='none'">${item.title || item.url}
+          <img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px">${item.title || item.url}
         </a>
         <div class="deferred-meta">
           <span>${domain}</span>
           <span>${ago}</span>
         </div>
       </div>
+      <button class="deferred-restore" data-action="restore-deferred" data-deferred-id="${item.id}" title="Reopen as a tab">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>
+      </button>
       <button class="deferred-dismiss" data-action="dismiss-deferred" data-deferred-id="${item.id}" title="Dismiss">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
       </button>
@@ -995,11 +1280,204 @@ function renderDeferredItem(item) {
 function renderArchiveItem(item) {
   const ago = item.completedAt ? timeAgo(item.completedAt) : timeAgo(item.savedAt);
   return `
-    <div class="archive-item">
+    <div class="archive-item" data-deferred-id="${item.id}">
       <a href="${item.url}" target="_blank" rel="noopener" class="archive-item-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
         ${item.title || item.url}
       </a>
       <span class="archive-item-date">${ago}</span>
+      <button class="archive-restore" data-action="restore-archived" data-deferred-id="${item.id}" title="Restore to Saved for Later">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" /></svg>
+      </button>
+    </div>`;
+}
+
+/**
+ * buildGroupWorkspaceBadge(group, storedIcons, liveWorkspaces)
+ *
+ * Inspects the group's non-dismissed items to figure out which Opera GX
+ * workspaces they came from. Returns an HTML fragment for the header's meta
+ * line.
+ *
+ *   - single workspace  → "<icon> Name"
+ *   - deleted workspace → "Name (deleted)" with muted style (requires
+ *                         liveWorkspaces to be populated — otherwise we
+ *                         assume the live map is just unavailable and fall
+ *                         back to the stored name as-is)
+ *   - multiple          → "Name + OtherName"  (icons omitted to save space)
+ *   - no workspace info → "" (caller falls back to just the time)
+ */
+function buildGroupWorkspaceBadge(group, storedIcons = {}, liveWorkspaces = new Map()) {
+  const escape = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const liveKnown = liveWorkspaces && liveWorkspaces.size > 0;
+
+  // workspaceId -> { name, isDeleted }
+  const seen = new Map();
+  for (const item of (group.items || [])) {
+    if (item.dismissed) continue;
+    if (!item.workspaceId) continue;
+    if (seen.has(item.workspaceId)) continue;
+    const live = liveWorkspaces.get(item.workspaceId);
+    if (live) {
+      seen.set(item.workspaceId, { name: live, isDeleted: false });
+    } else if (item.workspaceName) {
+      // Only flag as deleted when we're confident the live map is authoritative.
+      seen.set(item.workspaceId, { name: item.workspaceName, isDeleted: liveKnown });
+    }
+  }
+  if (seen.size === 0) return '';
+
+  const entries = [...seen.values()];
+  if (entries.length === 1) {
+    const { name, isDeleted } = entries[0];
+    const icon = isDeleted ? null : storedIcons[name];
+    const iconHtml = icon ? `<span class="group-ws-icon">${escape(icon)}</span>` : '';
+    const cls   = isDeleted ? 'group-ws-badge deleted' : 'group-ws-badge';
+    const label = isDeleted ? `${escape(name)} (deleted)` : escape(name);
+    const title = isDeleted ? `Workspace deleted: ${name}` : `Workspace: ${name}`;
+    return `<span class="${cls}" title="${escape(title)}">${iconHtml}${label}</span>`;
+  }
+
+  // 2+ workspaces (only possible for legacy saves from before split-by-workspace).
+  const joined  = entries.map(e => e.isDeleted ? `${escape(e.name)} (deleted)` : escape(e.name)).join(' + ');
+  const tipText = entries.map(e => e.isDeleted ? `${e.name} (deleted)` : e.name).join(', ');
+  return `<span class="group-ws-badge multi" title="Workspaces: ${escape(tipText)}">${joined}</span>`;
+}
+
+/**
+ * renderDeferredGroup(group, storedIcons)
+ *
+ * Builds HTML for a saved GROUP (many tabs) in the active "Saved for Later"
+ * column. Header shows favicon + domain label + item count and three header
+ * actions (restore all, check-off-to-archive, dismiss). Body lists each
+ * non-dismissed tab with per-item restore + dismiss buttons. Collapsible.
+ */
+function renderDeferredGroup(group, storedIcons = {}, liveWorkspaces = new Map()) {
+  const visibleItems = (group.items || []).filter(i => !i.dismissed);
+  const count = visibleItems.length;
+  const ago = timeAgo(group.savedAt);
+  const faviconUrl = group.domain
+    ? `https://www.google.com/s2/favicons?domain=${group.domain}&sz=16`
+    : '';
+  const safeLabel = (group.label || 'Group').replace(/"/g, '&quot;');
+  const wsBadge = buildGroupWorkspaceBadge(group, storedIcons, liveWorkspaces);
+  const metaHtml = wsBadge ? `${wsBadge} <span class="group-meta-dot">·</span> ${ago}` : ago;
+
+  const itemsHtml = visibleItems.map(item => {
+    const safeTitle = (item.title || item.url || '').replace(/"/g, '&quot;');
+    let itemDomain = '';
+    try { itemDomain = new URL(item.url).hostname.replace(/^www\./, ''); } catch {}
+    const itemFavicon = itemDomain
+      ? `https://www.google.com/s2/favicons?domain=${itemDomain}&sz=16`
+      : '';
+    return `
+      <div class="group-item" data-group-id="${group.id}" data-item-id="${item.id}">
+        <a href="${item.url}" target="_blank" rel="noopener" class="group-item-title" title="${safeTitle}">
+          ${itemFavicon ? `<img src="${itemFavicon}" alt="" class="group-item-favicon">` : ''}
+          <span class="group-item-text">${item.title || item.url}</span>
+        </a>
+        <button class="deferred-restore" data-action="restore-group-item" data-group-id="${group.id}" data-item-id="${item.id}" title="Reopen as a tab">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>
+        </button>
+        <button class="deferred-dismiss" data-action="dismiss-group-item" data-group-id="${group.id}" data-item-id="${item.id}" title="Dismiss">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+        </button>
+      </div>`;
+  }).join('');
+
+  return `
+    <div class="deferred-group" data-group-id="${group.id}">
+      <div class="group-header">
+        <button class="group-toggle" data-action="toggle-group" data-group-id="${group.id}" title="Expand/collapse">
+          <svg class="group-chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+        </button>
+        <div class="group-header-info">
+          <div class="group-header-title" title="${safeLabel}">
+            ${faviconUrl ? `<img src="${faviconUrl}" alt="" class="group-header-favicon">` : ''}
+            <span class="group-header-label">${group.label || 'Group'}</span>
+            <span class="group-header-count">${count} tab${count !== 1 ? 's' : ''}</span>
+          </div>
+          <div class="group-header-meta">${metaHtml}</div>
+        </div>
+        <button class="group-header-action" data-action="restore-group-all" data-group-id="${group.id}" title="Reopen all tabs">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>
+        </button>
+        <button class="group-header-action group-check" data-action="check-group" data-group-id="${group.id}" title="Archive this group">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5" /><path stroke-linecap="round" stroke-linejoin="round" d="M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>
+        </button>
+        <button class="group-header-action" data-action="dismiss-group" data-group-id="${group.id}" title="Dismiss (delete)">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+        </button>
+      </div>
+      <div class="group-body">${itemsHtml}</div>
+    </div>`;
+}
+
+/**
+ * renderArchiveGroup(group)
+ *
+ * Builds HTML for a saved group that's been archived. Header has
+ * "Restore all" (opens every tab and dismisses the archive entry) and
+ * "Move back to saved". Body has per-item restore + dismiss, identical
+ * to the active group body.
+ */
+function renderArchiveGroup(group, storedIcons = {}, liveWorkspaces = new Map()) {
+  const visibleItems = (group.items || []).filter(i => !i.dismissed);
+  const count = visibleItems.length;
+  const ago = group.completedAt ? timeAgo(group.completedAt) : timeAgo(group.savedAt);
+  const faviconUrl = group.domain
+    ? `https://www.google.com/s2/favicons?domain=${group.domain}&sz=16`
+    : '';
+  const safeLabel = (group.label || 'Group').replace(/"/g, '&quot;');
+  const wsBadge = buildGroupWorkspaceBadge(group, storedIcons, liveWorkspaces);
+  const metaHtml = wsBadge ? `${wsBadge} <span class="group-meta-dot">·</span> ${ago}` : ago;
+
+  const itemsHtml = visibleItems.map(item => {
+    const safeTitle = (item.title || item.url || '').replace(/"/g, '&quot;');
+    let itemDomain = '';
+    try { itemDomain = new URL(item.url).hostname.replace(/^www\./, ''); } catch {}
+    const itemFavicon = itemDomain
+      ? `https://www.google.com/s2/favicons?domain=${itemDomain}&sz=16`
+      : '';
+    return `
+      <div class="group-item archived" data-group-id="${group.id}" data-item-id="${item.id}">
+        <a href="${item.url}" target="_blank" rel="noopener" class="group-item-title" title="${safeTitle}">
+          ${itemFavicon ? `<img src="${itemFavicon}" alt="" class="group-item-favicon">` : ''}
+          <span class="group-item-text">${item.title || item.url}</span>
+        </a>
+        <button class="deferred-restore" data-action="restore-group-item" data-group-id="${group.id}" data-item-id="${item.id}" title="Reopen as a tab">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>
+        </button>
+        <button class="deferred-dismiss" data-action="dismiss-group-item" data-group-id="${group.id}" data-item-id="${item.id}" title="Dismiss">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+        </button>
+      </div>`;
+  }).join('');
+
+  return `
+    <div class="deferred-group archived" data-group-id="${group.id}">
+      <div class="group-header">
+        <button class="group-toggle" data-action="toggle-group" data-group-id="${group.id}" title="Expand/collapse">
+          <svg class="group-chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" /></svg>
+        </button>
+        <div class="group-header-info">
+          <div class="group-header-title" title="${safeLabel}">
+            ${faviconUrl ? `<img src="${faviconUrl}" alt="" class="group-header-favicon">` : ''}
+            <span class="group-header-label">${group.label || 'Group'}</span>
+            <span class="group-header-count">${count} tab${count !== 1 ? 's' : ''}</span>
+          </div>
+          <div class="group-header-meta">${metaHtml}</div>
+        </div>
+        <button class="group-header-action" data-action="restore-group-all" data-group-id="${group.id}" title="Reopen all tabs">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>
+        </button>
+        <button class="group-header-action" data-action="restore-archived-group" data-group-id="${group.id}" title="Move back to Saved for Later">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 15 3 9m0 0 6-6M3 9h12a6 6 0 0 1 0 12h-3" /></svg>
+        </button>
+        <button class="group-header-action" data-action="dismiss-group" data-group-id="${group.id}" title="Dismiss (delete)">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+        </button>
+      </div>
+      <div class="group-body">${itemsHtml}</div>
     </div>`;
 }
 
@@ -1030,42 +1508,76 @@ async function renderStaticDashboard() {
   await fetchOpenTabs();
   const realTabs = getRealTabs();
 
-  // --- Group tabs by domain ---
-  // Landing pages (Gmail inbox, Twitter home, etc.) get their own special group
-  // so they can be closed together without affecting content tabs on the same domain.
-  const LANDING_PAGE_PATTERNS = [
-    { hostname: 'mail.google.com', test: (p, h) =>
-        !h.includes('#inbox/') && !h.includes('#sent/') && !h.includes('#search/') },
-    { hostname: 'x.com',               pathExact: ['/home'] },
-    { hostname: 'www.linkedin.com',    pathExact: ['/'] },
-    { hostname: 'github.com',          pathExact: ['/'] },
-    { hostname: 'www.youtube.com',     pathExact: ['/'] },
-    // Merge personal patterns from config.local.js (if it exists)
-    ...(typeof LOCAL_LANDING_PAGE_PATTERNS !== 'undefined' ? LOCAL_LANDING_PAGE_PATTERNS : []),
-  ];
+  // --- Opera GX workspace filter bar ---
+  // Workspace icons live entirely in chrome.storage.local, keyed by workspace
+  // name. They're managed via the in-UI emoji picker (the pencil on each pill).
+  const storedIcons = await getWorkspaceIconOverrides();
 
-  function isLandingPage(url) {
-    try {
-      const parsed = new URL(url);
-      return LANDING_PAGE_PATTERNS.some(p => {
-        // Support both exact hostname and suffix matching (for wildcard subdomains)
-        const hostnameMatch = p.hostname
-          ? parsed.hostname === p.hostname
-          : p.hostnameEndsWith
-            ? parsed.hostname.endsWith(p.hostnameEndsWith)
-            : false;
-        if (!hostnameMatch) return false;
-        if (p.test)       return p.test(parsed.pathname, url);
-        if (p.pathPrefix) return parsed.pathname.startsWith(p.pathPrefix);
-        if (p.pathExact)  return p.pathExact.includes(parsed.pathname);
-        return parsed.pathname === '/';
-      });
-    } catch { return false; }
+  // Collect unique workspaces and remember the smallest tab.index in each, so
+  // we can present them in Opera GX's natural sidebar order (workspaces own
+  // contiguous ranges of tab indices, so min index ≈ leftmost in the sidebar).
+  const workspaceMap = new Map();  // workspaceId -> { name, icon, minIndex }
+  for (const t of realTabs) {
+    if (!t.workspaceId) continue;
+    const name = t.workspaceName || 'Workspace';
+    const idx  = typeof t.index === 'number' ? t.index : Number.MAX_SAFE_INTEGER;
+    const existing = workspaceMap.get(t.workspaceId);
+    if (!existing) {
+      workspaceMap.set(t.workspaceId, { name, icon: storedIcons[name] || null, minIndex: idx });
+    } else if (idx < existing.minIndex) {
+      existing.minIndex = idx;
+    }
+  }
+  // Sort entries by minIndex ascending — leftmost workspace first.
+  const sortedWorkspaces = [...workspaceMap.entries()].sort(
+    (a, b) => a[1].minIndex - b[1].minIndex
+  );
+  // Reset filter if the active workspace no longer exists (deleted / all tabs closed).
+  if (activeWorkspace && !workspaceMap.has(activeWorkspace)) {
+    activeWorkspace = null;
+  }
+  // Render the filter bar only when there are ≥2 workspaces. Non-Opera browsers
+  // return undefined workspaceId, so the Map stays empty and the bar stays hidden.
+  const filterEl = document.getElementById('workspaceFilter');
+  if (filterEl) {
+    if (workspaceMap.size >= 2) {
+      const escape = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+      const iconHtml = (icon) => {
+        if (!icon) return '';
+        const str = String(icon);
+        // If it looks like an image URL, render as <img>; otherwise treat as emoji/text.
+        if (/^(https?:|data:|chrome-extension:|\/)/i.test(str)) {
+          return `<img class="workspace-btn-icon" src="${escape(str)}" alt="">`;
+        }
+        return `<span class="workspace-btn-icon">${escape(str)}</span>`;
+      };
+      const allActive = activeWorkspace === null ? ' active' : '';
+      const allBtn = `<button class="workspace-btn${allActive}" data-action="filter-workspace">All</button>`;
+      const pencilSvg = `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Zm0 0L19.5 7.125" /></svg>`;
+      const wsBtns = sortedWorkspaces.map(([id, ws]) => {
+        const activeCls = activeWorkspace === id ? ' active' : '';
+        return `<span class="workspace-btn-wrap">
+          <button class="workspace-btn${activeCls}" data-action="filter-workspace" data-workspace-id="${escape(id)}">${iconHtml(ws.icon)}${escape(ws.name)}</button>
+          <button class="workspace-btn-edit" data-action="open-icon-picker" data-workspace-name="${escape(ws.name)}" title="Change icon">${pencilSvg}</button>
+        </span>`;
+      }).join('');
+      filterEl.innerHTML = allBtn + wsBtns;
+      filterEl.style.display = 'flex';
+    } else {
+      filterEl.style.display = 'none';
+      filterEl.innerHTML = '';
+    }
   }
 
+  // Apply the workspace filter before grouping — landing-page extraction,
+  // custom groups, and domain grouping all flow from filteredTabs.
+  const filteredTabs = activeWorkspace
+    ? realTabs.filter(t => t.workspaceId === activeWorkspace)
+    : realTabs;
+
+  // --- Group tabs by domain ---
   domainGroups = [];
-  const groupMap    = {};
-  const landingTabs = [];
+  const groupMap = {};
 
   // Custom group rules from config.local.js (if any)
   const customGroups = typeof LOCAL_CUSTOM_GROUPS !== 'undefined' ? LOCAL_CUSTOM_GROUPS : [];
@@ -1087,13 +1599,8 @@ async function renderStaticDashboard() {
     } catch { return null; }
   }
 
-  for (const tab of realTabs) {
+  for (const tab of filteredTabs) {
     try {
-      if (isLandingPage(tab.url)) {
-        landingTabs.push(tab);
-        continue;
-      }
-
       // Check custom group rules first (e.g. merge subdomains, split by path)
       const customRule = matchCustomGroup(tab.url);
       if (customRule) {
@@ -1118,29 +1625,8 @@ async function renderStaticDashboard() {
     }
   }
 
-  if (landingTabs.length > 0) {
-    groupMap['__landing-pages__'] = { domain: '__landing-pages__', tabs: landingTabs };
-  }
-
-  // Sort: landing pages first, then domains from landing page sites, then by tab count
-  // Collect exact hostnames and suffix patterns for priority sorting
-  const landingHostnames = new Set(LANDING_PAGE_PATTERNS.map(p => p.hostname).filter(Boolean));
-  const landingSuffixes = LANDING_PAGE_PATTERNS.map(p => p.hostnameEndsWith).filter(Boolean);
-  function isLandingDomain(domain) {
-    if (landingHostnames.has(domain)) return true;
-    return landingSuffixes.some(s => domain.endsWith(s));
-  }
-  domainGroups = Object.values(groupMap).sort((a, b) => {
-    const aIsLanding = a.domain === '__landing-pages__';
-    const bIsLanding = b.domain === '__landing-pages__';
-    if (aIsLanding !== bIsLanding) return aIsLanding ? -1 : 1;
-
-    const aIsPriority = isLandingDomain(a.domain);
-    const bIsPriority = isLandingDomain(b.domain);
-    if (aIsPriority !== bIsPriority) return aIsPriority ? -1 : 1;
-
-    return b.tabs.length - a.tabs.length;
-  });
+  // Sort by tab count descending — busiest domain first
+  domainGroups = Object.values(groupMap).sort((a, b) => b.tabs.length - a.tabs.length);
 
   // --- Render domain cards ---
   const openTabsSection      = document.getElementById('openTabsSection');
@@ -1150,16 +1636,15 @@ async function renderStaticDashboard() {
 
   if (domainGroups.length > 0 && openTabsSection) {
     if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-    openTabsSectionCount.innerHTML = `${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&middot;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
+    const dCount = domainGroups.length;
+    const tCount = filteredTabs.length;
+    openTabsSectionCount.textContent =
+      `${dCount} domain${dCount !== 1 ? 's' : ''} · ${tCount} tab${tCount !== 1 ? 's' : ''}`;
     openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
     openTabsSection.style.display = 'block';
   } else if (openTabsSection) {
     openTabsSection.style.display = 'none';
   }
-
-  // --- Footer stats ---
-  const statTabs = document.getElementById('statTabs');
-  if (statTabs) statTabs.textContent = openTabs.length;
 
   // --- Check for duplicate Tab Out tabs ---
   checkTabOutDupes();
@@ -1188,6 +1673,56 @@ document.addEventListener('click', async (e) => {
 
   const action = actionEl.dataset.action;
 
+  // ---- Filter by Opera GX workspace ----
+  if (action === 'filter-workspace') {
+    const wsId = actionEl.dataset.workspaceId || null;
+    if (activeWorkspace === wsId) return;  // already active — no work to do
+    activeWorkspace = wsId;
+    await renderStaticDashboard();
+    return;
+  }
+
+  // ---- Open the workspace icon picker ----
+  if (action === 'open-icon-picker') {
+    e.stopPropagation();
+    const name = actionEl.dataset.workspaceName;
+    if (!name) return;
+    openIconPicker(actionEl, name);
+    return;
+  }
+
+  // ---- Pick an icon from the grid ----
+  if (action === 'pick-icon') {
+    e.stopPropagation();
+    const picker = document.getElementById('iconPicker');
+    const name = picker && picker.dataset.workspaceName;
+    const icon = actionEl.dataset.icon;
+    if (!name || !icon) return;
+    await setWorkspaceIconOverride(name, icon);
+    closeIconPicker();
+    await renderStaticDashboard();
+    return;
+  }
+
+  // ---- Clear the current workspace's icon override ----
+  if (action === 'clear-icon') {
+    e.stopPropagation();
+    const picker = document.getElementById('iconPicker');
+    const name = picker && picker.dataset.workspaceName;
+    if (!name) return;
+    await setWorkspaceIconOverride(name, null);
+    closeIconPicker();
+    await renderStaticDashboard();
+    return;
+  }
+
+  // ---- Close the picker via its X ----
+  if (action === 'close-icon-picker') {
+    e.stopPropagation();
+    closeIconPicker();
+    return;
+  }
+
   // ---- Close duplicate Tab Out tabs ----
   if (action === 'close-tabout-dupes') {
     await closeTabOutDupes();
@@ -1206,7 +1741,9 @@ document.addEventListener('click', async (e) => {
 
   // ---- Expand overflow chips ("+N more") ----
   if (action === 'expand-chips') {
-    const overflowContainer = actionEl.parentElement.querySelector('.page-chips-overflow');
+    const parent = actionEl.parentElement;
+    if (!parent) return;
+    const overflowContainer = parent.querySelector('.page-chips-overflow');
     if (overflowContainer) {
       overflowContainer.style.display = 'contents';
       actionEl.remove();
@@ -1256,10 +1793,7 @@ document.addEventListener('click', async (e) => {
       }, 200);
     }
 
-    // Update footer
-    const statTabs = document.getElementById('statTabs');
-    if (statTabs) statTabs.textContent = openTabs.length;
-
+    // The chrome.tabs.onRemoved listener will auto-refresh the section count.
     showToast('Tab closed');
     return;
   }
@@ -1271,9 +1805,19 @@ document.addEventListener('click', async (e) => {
     const tabTitle = actionEl.dataset.tabTitle || tabUrl;
     if (!tabUrl) return;
 
+    // Find the source tab so we can remember its Opera GX workspace + position
+    const sourceTab = openTabs.find(t => t.url === tabUrl);
+
     // Save to chrome.storage.local
     try {
-      await saveTabForLater({ url: tabUrl, title: tabTitle });
+      await saveTabForLater({
+        url:           tabUrl,
+        title:         tabTitle,
+        workspaceId:   sourceTab && sourceTab.workspaceId,
+        workspaceName: sourceTab && sourceTab.workspaceName,
+        index:         sourceTab && sourceTab.index,
+        windowId:      sourceTab && sourceTab.windowId,
+      });
     } catch (err) {
       console.error('[tab-out] Failed to save tab:', err);
       showToast('Failed to save tab');
@@ -1340,6 +1884,355 @@ document.addEventListener('click', async (e) => {
     return;
   }
 
+  // ---- Restore a saved-for-later tab back to the browser ----
+  if (action === 'restore-deferred') {
+    e.stopPropagation();
+    const id = actionEl.dataset.deferredId;
+    if (!id) return;
+
+    // Pull the full record from storage so we get url + workspace + position together
+    const { deferred = [] } = await chrome.storage.local.get('deferred');
+    const stored = deferred.find(t => t.id === id);
+    if (!stored || !stored.url) return;
+
+    // Build create options. Only include each field if we know it — undefined
+    // would shadow Chrome's defaults.
+    const createOpts = { url: stored.url, active: false };
+    if (stored.workspaceId != null) createOpts.workspaceId = stored.workspaceId;
+    if (stored.windowId    != null) createOpts.windowId    = stored.windowId;
+    if (stored.index       != null) createOpts.index       = stored.index;
+
+    let createdTab;
+    try {
+      createdTab = await chrome.tabs.create(createOpts);
+    } catch (err) {
+      // windowId may have closed since save — retry without it
+      if (createOpts.windowId != null) {
+        try {
+          delete createOpts.windowId;
+          createdTab = await chrome.tabs.create(createOpts);
+        } catch (err2) {
+          console.error('[tab-out] Failed to reopen tab:', err2);
+          showToast('Could not reopen tab');
+          return;
+        }
+      } else {
+        console.error('[tab-out] Failed to reopen tab:', err);
+        showToast('Could not reopen tab');
+        return;
+      }
+    }
+
+    // If a workspace was requested but didn't stick at creation, patch it on.
+    // Some Opera GX builds need workspaceId via tabs.update rather than create.
+    if (stored.workspaceId != null && createdTab && createdTab.workspaceId !== stored.workspaceId) {
+      try {
+        await chrome.tabs.update(createdTab.id, { workspaceId: stored.workspaceId });
+      } catch {
+        // Older Opera GX may not support workspaceId on update — tab still opens.
+      }
+    }
+
+    // Now that the tab is open, remove it from the saved-for-later list
+    await dismissSavedTab(id);
+
+    const item = actionEl.closest('.deferred-item');
+    if (item) {
+      item.classList.add('removing');
+      setTimeout(() => {
+        item.remove();
+        renderDeferredColumn();
+        renderStaticDashboard();
+      }, 300);
+    } else {
+      await renderStaticDashboard();
+    }
+
+    showToast('Reopened as a tab');
+    return;
+  }
+
+  // ---- Save the whole domain group for later (active checklist) ----
+  if (action === 'save-domain-group' || action === 'archive-domain-group') {
+    const directToArchive = action === 'archive-domain-group';
+    const domainId = actionEl.dataset.domainId;
+    const group    = domainGroups.find(g =>
+      'domain-' + g.domain.replace(/[^a-z0-9]/g, '-') === domainId
+    );
+    if (!group) return;
+
+    // Split tabs by Opera GX workspaceId so each workspace becomes its OWN
+    // saved group — makes it obvious which domain tabs came from which
+    // workspace when reviewing later. Tabs with no workspaceId (e.g. non-Opera)
+    // share a single bucket.
+    const buckets = new Map();
+    for (const tab of (group.tabs || [])) {
+      const key = tab.workspaceId != null ? tab.workspaceId : '__none__';
+      if (!buckets.has(key)) buckets.set(key, []);
+      buckets.get(key).push(tab);
+    }
+    // Preserve Opera GX sidebar ordering — bucket with the smallest tab
+    // index ends up first in the saved list.
+    const bucketLists = [...buckets.values()].sort((a, b) => {
+      const ai = Math.min(...a.map(t => (typeof t.index === 'number') ? t.index : Infinity));
+      const bi = Math.min(...b.map(t => (typeof t.index === 'number') ? t.index : Infinity));
+      return ai - bi;
+    });
+
+    // Persist each bucket as its own group so renderDeferredGroup later
+    // shows one card per workspace with a clean single-workspace badge.
+    const saveStart = Date.now();
+    try {
+      for (let i = 0; i < bucketLists.length; i++) {
+        await saveGroupForLater(
+          { ...group, tabs: bucketLists[i] },
+          { directToArchive, baseId: `${saveStart}-${i}` }
+        );
+      }
+    } catch (err) {
+      console.error('[tab-out] Failed to save group:', err);
+      showToast('Failed to save group');
+      return;
+    }
+
+    // Close the browser tabs (reuse the same close rules as close-domain-tabs)
+    const urls     = group.tabs.map(t => t.url);
+    // Custom groups (label set) match exact URLs because their synthetic
+    // group key isn't a real hostname. Regular domain groups match by hostname.
+    const useExact = !!group.label;
+    if (useExact) await closeTabsExact(urls);
+    else          await closeTabsByUrls(urls);
+
+    if (card) {
+      playCloseSound();
+      animateCardOut(card);
+    }
+
+    // Remove from in-memory groups so the card doesn't resurrect on next render
+    const idx = domainGroups.indexOf(group);
+    if (idx !== -1) domainGroups.splice(idx, 1);
+
+    const noun = directToArchive ? 'Archived' : 'Saved';
+    const groupLabel = group.label || friendlyDomain(group.domain);
+    const suffix     = bucketLists.length > 1 ? ` across ${bucketLists.length} workspaces` : '';
+    showToast(`${noun} ${urls.length} tab${urls.length !== 1 ? 's' : ''} from ${groupLabel}${suffix}`);
+
+    await renderDeferredColumn();
+    return;
+  }
+
+  // ---- Toggle a saved group's expand/collapse state ----
+  if (action === 'toggle-group') {
+    const groupEl = actionEl.closest('.deferred-group');
+    if (groupEl) groupEl.classList.toggle('collapsed');
+    return;
+  }
+
+  // ---- Restore all tabs in a saved group (active OR archived) ----
+  if (action === 'restore-group-all') {
+    const groupId = actionEl.dataset.groupId;
+    if (!groupId) return;
+
+    const { deferred = [] } = await chrome.storage.local.get('deferred');
+    const group = deferred.find(g => g.id === groupId && g.kind === 'group');
+    if (!group) return;
+
+    const items = (group.items || []).filter(i => !i.dismissed);
+    if (items.length === 0) {
+      // Nothing left to restore — just dismiss the now-empty group
+      await dismissGroup(groupId);
+      await renderDeferredColumn();
+      return;
+    }
+
+    // Restore every tab in its original workspace / index / window (best-effort).
+    // Sort by index ascending so inserts land in a predictable order.
+    const sorted = [...items].sort((a, b) =>
+      (a.index ?? Number.MAX_SAFE_INTEGER) - (b.index ?? Number.MAX_SAFE_INTEGER)
+    );
+    for (const item of sorted) {
+      const createOpts = { url: item.url, active: false };
+      if (item.workspaceId != null) createOpts.workspaceId = item.workspaceId;
+      if (item.windowId    != null) createOpts.windowId    = item.windowId;
+      if (item.index       != null) createOpts.index       = item.index;
+      let created;
+      try {
+        created = await chrome.tabs.create(createOpts);
+      } catch {
+        // windowId may have closed — retry without it
+        if (createOpts.windowId != null) {
+          try {
+            delete createOpts.windowId;
+            created = await chrome.tabs.create(createOpts);
+          } catch (err2) {
+            console.error('[tab-out] Could not reopen', item.url, err2);
+            continue;
+          }
+        } else {
+          console.error('[tab-out] Could not reopen', item.url);
+          continue;
+        }
+      }
+      // Patch workspaceId if the create didn't honor it
+      if (item.workspaceId != null && created && created.workspaceId !== item.workspaceId) {
+        try { await chrome.tabs.update(created.id, { workspaceId: item.workspaceId }); }
+        catch {}
+      }
+    }
+
+    // All tabs are open — dismiss the saved group entirely
+    await dismissGroup(groupId);
+    showToast(`Reopened ${items.length} tab${items.length !== 1 ? 's' : ''}`);
+    await renderDeferredColumn();
+    await renderStaticDashboard();
+    return;
+  }
+
+  // ---- Restore one item from a saved group ----
+  if (action === 'restore-group-item') {
+    const groupId = actionEl.dataset.groupId;
+    const itemId  = actionEl.dataset.itemId;
+    if (!groupId || !itemId) return;
+
+    const { deferred = [] } = await chrome.storage.local.get('deferred');
+    const group = deferred.find(g => g.id === groupId && g.kind === 'group');
+    if (!group) return;
+    const item = group.items.find(i => i.id === itemId);
+    if (!item || item.dismissed) return;
+
+    const createOpts = { url: item.url, active: false };
+    if (item.workspaceId != null) createOpts.workspaceId = item.workspaceId;
+    if (item.windowId    != null) createOpts.windowId    = item.windowId;
+    if (item.index       != null) createOpts.index       = item.index;
+
+    let created;
+    try {
+      created = await chrome.tabs.create(createOpts);
+    } catch {
+      if (createOpts.windowId != null) {
+        try {
+          delete createOpts.windowId;
+          created = await chrome.tabs.create(createOpts);
+        } catch (err2) {
+          console.error('[tab-out] Could not reopen', item.url, err2);
+          showToast('Could not reopen tab');
+          return;
+        }
+      } else {
+        console.error('[tab-out] Could not reopen', item.url);
+        showToast('Could not reopen tab');
+        return;
+      }
+    }
+    if (item.workspaceId != null && created && created.workspaceId !== item.workspaceId) {
+      try { await chrome.tabs.update(created.id, { workspaceId: item.workspaceId }); }
+      catch {}
+    }
+
+    // Mark the item dismissed; auto-dismiss the group if it's now empty
+    await dismissGroupItem(groupId, itemId);
+
+    const itemRow = actionEl.closest('.group-item');
+    if (itemRow) {
+      itemRow.classList.add('removing');
+      setTimeout(() => {
+        itemRow.remove();
+        renderDeferredColumn();
+        renderStaticDashboard();
+      }, 250);
+    } else {
+      await renderDeferredColumn();
+      await renderStaticDashboard();
+    }
+
+    showToast('Reopened as a tab');
+    return;
+  }
+
+  // ---- Dismiss one item from a saved group (without opening it) ----
+  if (action === 'dismiss-group-item') {
+    const groupId = actionEl.dataset.groupId;
+    const itemId  = actionEl.dataset.itemId;
+    if (!groupId || !itemId) return;
+
+    await dismissGroupItem(groupId, itemId);
+
+    const itemRow = actionEl.closest('.group-item');
+    if (itemRow) {
+      itemRow.classList.add('removing');
+      setTimeout(() => {
+        itemRow.remove();
+        renderDeferredColumn();
+      }, 250);
+    } else {
+      await renderDeferredColumn();
+    }
+    return;
+  }
+
+  // ---- Check off a saved group (move to archive) ----
+  if (action === 'check-group') {
+    const groupId = actionEl.dataset.groupId;
+    if (!groupId) return;
+    await checkOffGroup(groupId);
+    showToast('Group archived');
+    await renderDeferredColumn();
+    return;
+  }
+
+  // ---- Dismiss an entire saved group (delete it) ----
+  if (action === 'dismiss-group') {
+    const groupId = actionEl.dataset.groupId;
+    if (!groupId) return;
+    await dismissGroup(groupId);
+
+    const groupEl = actionEl.closest('.deferred-group');
+    if (groupEl) {
+      groupEl.classList.add('removing');
+      setTimeout(() => {
+        groupEl.remove();
+        renderDeferredColumn();
+      }, 250);
+    } else {
+      await renderDeferredColumn();
+    }
+    return;
+  }
+
+  // ---- Move an archived group back to active Saved for Later ----
+  if (action === 'restore-archived-group') {
+    const groupId = actionEl.dataset.groupId;
+    if (!groupId) return;
+    await restoreArchivedGroup(groupId);
+    showToast('Restored to Saved for Later');
+    await renderDeferredColumn();
+    return;
+  }
+
+  // ---- Restore an archived tab back to active "Saved for Later" ----
+  if (action === 'restore-archived') {
+    const id = actionEl.dataset.deferredId;
+    if (!id) return;
+
+    await restoreArchivedTab(id);
+
+    const item = actionEl.closest('.archive-item');
+    if (item) {
+      item.style.transition = 'opacity 0.25s, transform 0.25s';
+      item.style.opacity    = '0';
+      item.style.transform  = 'translateX(-10px)';
+      setTimeout(() => {
+        item.remove();
+        renderDeferredColumn();
+      }, 250);
+    } else {
+      await renderDeferredColumn();
+    }
+
+    showToast('Restored to Saved for Later');
+    return;
+  }
+
   // ---- Close all tabs in a domain group ----
   if (action === 'close-domain-tabs') {
     const domainId = actionEl.dataset.domainId;
@@ -1348,10 +2241,10 @@ document.addEventListener('click', async (e) => {
     });
     if (!group) return;
 
-    const urls      = group.tabs.map(t => t.url);
-    // Landing pages and custom groups (whose domain key isn't a real hostname)
-    // must use exact URL matching to avoid closing unrelated tabs
-    const useExact  = group.domain === '__landing-pages__' || !!group.label;
+    const urls     = group.tabs.map(t => t.url);
+    // Custom groups (label set) use a synthetic key as group.domain so we
+    // have to match by exact URL. Regular domain groups match by hostname.
+    const useExact = !!group.label;
 
     if (useExact) {
       await closeTabsExact(urls);
@@ -1368,11 +2261,10 @@ document.addEventListener('click', async (e) => {
     const idx = domainGroups.indexOf(group);
     if (idx !== -1) domainGroups.splice(idx, 1);
 
-    const groupLabel = group.domain === '__landing-pages__' ? 'Homepages' : (group.label || friendlyDomain(group.domain));
+    const groupLabel = group.label || friendlyDomain(group.domain);
     showToast(`Closed ${urls.length} tab${urls.length !== 1 ? 's' : ''} from ${groupLabel}`);
 
-    const statTabs = document.getElementById('statTabs');
-    if (statTabs) statTabs.textContent = openTabs.length;
+    // The chrome.tabs.onRemoved listener will auto-refresh the section count.
     return;
   }
 
@@ -1412,25 +2304,6 @@ document.addEventListener('click', async (e) => {
     return;
   }
 
-  // ---- Close ALL open tabs ----
-  if (action === 'close-all-open-tabs') {
-    const allUrls = openTabs
-      .filter(t => t.url && !t.url.startsWith('chrome') && !t.url.startsWith('about:'))
-      .map(t => t.url);
-    await closeTabsByUrls(allUrls);
-    playCloseSound();
-
-    document.querySelectorAll('#openTabsMissions .mission-card').forEach(c => {
-      shootConfetti(
-        c.getBoundingClientRect().left + c.offsetWidth / 2,
-        c.getBoundingClientRect().top  + c.offsetHeight / 2
-      );
-      animateCardOut(c);
-    });
-
-    showToast('All tabs closed. Fresh start.');
-    return;
-  }
 });
 
 // ---- Archive toggle — expand/collapse the archive section ----
@@ -1445,6 +2318,33 @@ document.addEventListener('click', (e) => {
   }
 });
 
+// ---- Icon picker: click-outside closes it, Escape closes it ----
+document.addEventListener('click', (e) => {
+  const picker = document.getElementById('iconPicker');
+  if (!picker || picker.style.display === 'none') return;
+  if (picker.contains(e.target)) return;                // click inside picker — fine
+  if (e.target.closest('[data-action="open-icon-picker"]')) return; // opening click — fine
+  closeIconPicker();
+});
+
+document.addEventListener('keydown', (e) => {
+  if (e.key !== 'Escape') return;
+  const picker = document.getElementById('iconPicker');
+  if (picker && picker.style.display !== 'none') closeIconPicker();
+});
+
+// ---- Icon picker: free-form input (accepts any emoji / paste / Win+.) ----
+document.addEventListener('change', async (e) => {
+  if (e.target.id !== 'iconPickerInput') return;
+  const picker = document.getElementById('iconPicker');
+  const name = picker && picker.dataset.workspaceName;
+  const value = (e.target.value || '').trim();
+  if (!name || !value) return;
+  await setWorkspaceIconOverride(name, value);
+  closeIconPicker();
+  await renderStaticDashboard();
+});
+
 // ---- Archive search — filter archived items as user types ----
 document.addEventListener('input', async (e) => {
   if (e.target.id !== 'archiveSearch') return;
@@ -1455,25 +2355,169 @@ document.addEventListener('input', async (e) => {
 
   try {
     const { archived } = await getSavedTabs();
+    const storedIcons    = await getWorkspaceIconOverrides();
+    const liveWorkspaces = buildLiveWorkspaceMap();
+    const renderEntry = (item) =>
+      item.kind === 'group'
+        ? renderArchiveGroup(item, storedIcons, liveWorkspaces)
+        : renderArchiveItem(item);
 
     if (q.length < 2) {
-      // Show all archived items
-      archiveList.innerHTML = archived.map(item => renderArchiveItem(item)).join('');
+      archiveList.innerHTML = archived.map(renderEntry).join('');
       return;
     }
 
-    // Filter by title or URL containing the query string
-    const results = archived.filter(item =>
-      (item.title || '').toLowerCase().includes(q) ||
-      (item.url  || '').toLowerCase().includes(q)
-    );
+    // Match individual tabs by title/url. Match groups by label OR by any
+    // non-dismissed item inside the group matching title/url.
+    const results = archived.filter(item => {
+      if (item.kind === 'group') {
+        if ((item.label || '').toLowerCase().includes(q)) return true;
+        return (item.items || []).some(i =>
+          !i.dismissed && (
+            (i.title || '').toLowerCase().includes(q) ||
+            (i.url   || '').toLowerCase().includes(q)
+          )
+        );
+      }
+      return (item.title || '').toLowerCase().includes(q) ||
+             (item.url   || '').toLowerCase().includes(q);
+    });
 
-    archiveList.innerHTML = results.map(item => renderArchiveItem(item)).join('')
+    archiveList.innerHTML = results.map(renderEntry).join('')
       || '<div style="font-size:12px;color:var(--muted);padding:8px 0">No results</div>';
   } catch (err) {
     console.warn('[tab-out] Archive search failed:', err);
   }
 });
+
+
+/* ----------------------------------------------------------------
+   WORKSPACE ICON PICKER — render + position + close
+
+   Popover anchored to the clicked workspace's edit pencil. Contents
+   are built from EMOJI_CATEGORIES plus a free-form input so any emoji
+   (e.g. from Windows' Win+. picker) can be used.
+   ---------------------------------------------------------------- */
+
+function openIconPicker(anchorEl, workspaceName) {
+  const picker = document.getElementById('iconPicker');
+  if (!picker || !anchorEl) return;
+
+  const escape = s => String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  const safeName = escape(workspaceName);
+
+  const categoriesHtml = EMOJI_CATEGORIES.map(cat => {
+    const options = cat.emojis.map(e =>
+      `<button class="icon-picker-option" data-action="pick-icon" data-icon="${escape(e)}" title="${escape(e)}">${escape(e)}</button>`
+    ).join('');
+    return `<div class="icon-picker-section">
+      <div class="icon-picker-section-label">${escape(cat.name)}</div>
+      <div class="icon-picker-grid">${options}</div>
+    </div>`;
+  }).join('');
+
+  picker.dataset.workspaceName = workspaceName;
+  picker.innerHTML = `
+    <div class="icon-picker-header">
+      <span>Pick an icon for <strong>${safeName}</strong></span>
+      <button class="icon-picker-close" data-action="close-icon-picker" title="Close">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
+      </button>
+    </div>
+    <div class="icon-picker-body">${categoriesHtml}</div>
+    <div class="icon-picker-footer">
+      <input type="text" class="icon-picker-input" id="iconPickerInput" placeholder="Or paste / type any emoji (Win+. on Windows)" maxlength="8">
+      <button class="icon-picker-clear" data-action="clear-icon">Clear</button>
+    </div>
+  `;
+
+  // Show first so offsetWidth/Height are real, then position.
+  picker.style.display = 'block';
+  picker.style.visibility = 'hidden';
+
+  const anchorRect = anchorEl.getBoundingClientRect();
+  const pickerRect = picker.getBoundingClientRect();
+  const margin = 8;
+
+  let top = anchorRect.bottom + window.scrollY + 6;
+  let left = anchorRect.left + window.scrollX;
+
+  // Keep inside viewport horizontally
+  const maxLeft = window.scrollX + document.documentElement.clientWidth - pickerRect.width - margin;
+  if (left > maxLeft) left = maxLeft;
+  if (left < margin) left = margin;
+
+  // If it would overflow the bottom, flip above the anchor
+  const viewportBottom = window.scrollY + document.documentElement.clientHeight;
+  if (top + pickerRect.height + margin > viewportBottom) {
+    top = anchorRect.top + window.scrollY - pickerRect.height - 6;
+    if (top < window.scrollY + margin) top = window.scrollY + margin;
+  }
+
+  picker.style.top  = top + 'px';
+  picker.style.left = left + 'px';
+  picker.style.visibility = 'visible';
+
+  // Autofocus the free-form input so Win+. / paste works immediately
+  const input = document.getElementById('iconPickerInput');
+  if (input) input.focus();
+}
+
+function closeIconPicker() {
+  const picker = document.getElementById('iconPicker');
+  if (!picker) return;
+  picker.style.display = 'none';
+  picker.innerHTML = '';
+  delete picker.dataset.workspaceName;
+}
+
+
+/* ----------------------------------------------------------------
+   BROKEN-IMAGE FALLBACK
+
+   Extensions have strict CSP that disallows inline event handlers
+   like onerror="...", so we handle image-load failures globally.
+   `error` events don't bubble — use a capturing listener instead.
+   ---------------------------------------------------------------- */
+document.addEventListener('error', (e) => {
+  const el = e.target;
+  if (el && el.tagName === 'IMG') {
+    el.style.display = 'none';
+  }
+}, true);
+
+
+/* ----------------------------------------------------------------
+   LIVE TAB SYNC
+
+   Re-render the dashboard when tabs change OUTSIDE Tab Out (open / close /
+   move / navigate in another window). Debounced so a flurry of events
+   (e.g. closing many tabs at once) collapses to a single render.
+   ---------------------------------------------------------------- */
+
+let __renderDebounceTimer = null;
+function scheduleDashboardRefresh(delay = 400) {
+  if (__renderDebounceTimer) clearTimeout(__renderDebounceTimer);
+  __renderDebounceTimer = setTimeout(() => {
+    __renderDebounceTimer = null;
+    renderStaticDashboard();
+  }, delay);
+}
+
+if (typeof chrome !== 'undefined' && chrome.tabs) {
+  chrome.tabs.onCreated.addListener(() => scheduleDashboardRefresh());
+  chrome.tabs.onRemoved.addListener(() => scheduleDashboardRefresh());
+  chrome.tabs.onMoved.addListener(()   => scheduleDashboardRefresh());
+  chrome.tabs.onAttached.addListener(() => scheduleDashboardRefresh());
+  chrome.tabs.onDetached.addListener(() => scheduleDashboardRefresh());
+  // onUpdated fires for every loading-progress tick — only refresh on
+  // changes that actually affect what we display (URL, title, completion).
+  chrome.tabs.onUpdated.addListener((_id, changeInfo) => {
+    if (changeInfo.url || changeInfo.title || changeInfo.status === 'complete') {
+      scheduleDashboardRefresh();
+    }
+  });
+}
 
 
 /* ----------------------------------------------------------------

--- a/extension/app.js
+++ b/extension/app.js
@@ -1072,7 +1072,7 @@ function renderDomainCard(group) {
       ${saveIconSvg}
       Save
     </button>
-    <button class="action-btn" data-action="archive-domain-group" data-domain-id="${stableId}" title="Archive all tabs (skip the checklist)">
+    <button class="action-btn archive-tabs" data-action="archive-domain-group" data-domain-id="${stableId}" title="Archive all tabs (skip the checklist)">
       ${ICONS.archive}
       Archive
     </button>
@@ -1090,7 +1090,7 @@ function renderDomainCard(group) {
   }
 
   return `
-    <div class="mission-card domain-card ${hasDupes ? 'has-amber-bar' : 'has-neutral-bar'}" data-domain-id="${stableId}">
+    <div class="mission-card domain-card ${hasDupes ? 'has-amber-bar' : 'has-neutral-bar'}" data-domain-id="${stableId}" data-domain="${group.domain}">
       <div class="status-bar"></div>
       <div class="mission-content">
         <div class="mission-top">
@@ -1207,7 +1207,6 @@ function renderDeferredItem(item) {
 
   return `
     <div class="deferred-item" data-deferred-id="${item.id}">
-      <input type="checkbox" class="deferred-checkbox" data-action="check-deferred" data-deferred-id="${item.id}">
       <div class="deferred-info">
         <a href="${item.url}" target="_blank" rel="noopener" class="deferred-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
           <img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px">${item.title || item.url}
@@ -1451,6 +1450,79 @@ function renderArchiveGroup(group, storedIcons = {}, liveWorkspaces = new Map())
  * 5. Updates footer stats
  * 6. Renders the "Saved for Later" checklist
  */
+async function closeTabOutDupes() {
+  const extensionId = chrome.runtime.id;
+  const newtabUrl   = `chrome-extension://${extensionId}/index.html`;
+
+  const allTabs      = await chrome.tabs.query({});
+  const currentWindow = await chrome.windows.getCurrent();
+  const tabOutTabs   = allTabs.filter(t => t.url === newtabUrl);
+
+  if (tabOutTabs.length <= 1) return;
+
+  const keep =
+    tabOutTabs.find(t => t.active && t.windowId === currentWindow.id) ||
+    tabOutTabs.find(t => t.active) ||
+    tabOutTabs[0];
+  const toClose = tabOutTabs.filter(t => t.id !== keep.id).map(t => t.id);
+  if (toClose.length > 0) await chrome.tabs.remove(toClose);
+  await fetchOpenTabs();
+}
+
+function checkTabOutDupes() {
+  const extensionId = chrome.runtime.id;
+  const newtabUrl   = `chrome-extension://${extensionId}/index.html`;
+  const banner  = document.getElementById('tabOutDupeBanner');
+  const countEl = document.getElementById('tabOutDupeCount');
+  if (!banner) return;
+
+  chrome.tabs.query({}).then(allTabs => {
+    const tabOutTabs = allTabs.filter(t => t.url === newtabUrl);
+    if (tabOutTabs.length > 1) {
+      if (countEl) countEl.textContent = tabOutTabs.length;
+      banner.style.display = 'flex';
+    } else {
+      banner.style.display = 'none';
+    }
+  });
+}
+
+function flipDomainCards(container) {
+  const oldRects = new Map();
+  container.querySelectorAll('.mission-card[data-domain]').forEach(card => {
+    oldRects.set(card.dataset.domain, card.getBoundingClientRect());
+  });
+
+  return function playFlip() {
+    container.querySelectorAll('.mission-card[data-domain]').forEach(card => {
+      const domain = card.dataset.domain;
+      const newRect = card.getBoundingClientRect();
+      const oldRect = oldRects.get(domain);
+
+      if (oldRect) {
+        const dx = oldRect.left - newRect.left;
+        const dy = oldRect.top  - newRect.top;
+        if (dx === 0 && dy === 0) return;
+
+        card.style.transition = 'none';
+        card.style.transform  = `translate(${dx}px, ${dy}px)`;
+
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          card.style.transition = '';
+          card.style.transform  = '';
+        }));
+      } else {
+        card.style.transition = 'none';
+        card.style.opacity    = '0';
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          card.style.transition = 'opacity 0.3s ease';
+          card.style.opacity    = '';
+        }));
+      }
+    });
+  };
+}
+
 async function renderStaticDashboard() {
   // --- Header ---
   const greetingEl = document.getElementById('greeting');
@@ -1594,11 +1666,16 @@ async function renderStaticDashboard() {
     const tCount = filteredTabs.length;
     openTabsSectionCount.textContent =
       `${dCount} domain${dCount !== 1 ? 's' : ''} · ${tCount} tab${tCount !== 1 ? 's' : ''}`;
+    const playFlip = flipDomainCards(openTabsMissionsEl);
     openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
+    playFlip();
     openTabsSection.style.display = 'block';
   } else if (openTabsSection) {
     openTabsSection.style.display = 'none';
   }
+
+  // --- Check for duplicate Tab Out tabs ---
+  checkTabOutDupes();
 
   // --- Render "Saved for Later" column ---
   await renderDeferredColumn();
@@ -1671,6 +1748,20 @@ document.addEventListener('click', async (e) => {
   if (action === 'close-icon-picker') {
     e.stopPropagation();
     closeIconPicker();
+    return;
+  }
+
+  // ---- Close duplicate Tab Out tabs ----
+  if (action === 'close-tabout-dupes') {
+    await closeTabOutDupes();
+    playCloseSound();
+    const banner = document.getElementById('tabOutDupeBanner');
+    if (banner) {
+      banner.style.transition = 'opacity 0.4s';
+      banner.style.opacity = '0';
+      setTimeout(() => { banner.style.display = 'none'; banner.style.opacity = '1'; }, 400);
+    }
+    showToast('Closed extra Tab Out tabs');
     return;
   }
 
@@ -1778,28 +1869,6 @@ document.addEventListener('click', async (e) => {
 
     showToast('Saved for later');
     await renderDeferredColumn();
-    return;
-  }
-
-  // ---- Check off a saved tab (moves it to archive) ----
-  if (action === 'check-deferred') {
-    const id = actionEl.dataset.deferredId;
-    if (!id) return;
-
-    await checkOffSavedTab(id);
-
-    // Animate: strikethrough first, then slide out
-    const item = actionEl.closest('.deferred-item');
-    if (item) {
-      item.classList.add('checked');
-      setTimeout(() => {
-        item.classList.add('removing');
-        setTimeout(() => {
-          item.remove();
-          renderDeferredColumn(); // refresh counts and archive
-        }, 300);
-      }, 800);
-    }
     return;
   }
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -175,33 +175,6 @@ async function closeDuplicateTabs(urls, keepOne = true) {
   await fetchOpenTabs();
 }
 
-/**
- * closeTabOutDupes()
- *
- * Closes all duplicate Tab Out new-tab pages except the current one.
- */
-async function closeTabOutDupes() {
-  const extensionId = chrome.runtime.id;
-  const newtabUrl = `chrome-extension://${extensionId}/index.html`;
-
-  const allTabs = await chrome.tabs.query({});
-  const currentWindow = await chrome.windows.getCurrent();
-  const tabOutTabs = allTabs.filter(t =>
-    t.url === newtabUrl || t.url === 'chrome://newtab/'
-  );
-
-  if (tabOutTabs.length <= 1) return;
-
-  // Keep the active Tab Out tab in the CURRENT window — that's the one the
-  // user is looking at right now. Falls back to any active one, then the first.
-  const keep =
-    tabOutTabs.find(t => t.active && t.windowId === currentWindow.id) ||
-    tabOutTabs.find(t => t.active) ||
-    tabOutTabs[0];
-  const toClose = tabOutTabs.filter(t => t.id !== keep.id).map(t => t.id);
-  if (toClose.length > 0) await chrome.tabs.remove(toClose);
-  await fetchOpenTabs();
-}
 
 
 /* ----------------------------------------------------------------
@@ -975,25 +948,6 @@ function getRealTabs() {
   });
 }
 
-/**
- * checkTabOutDupes()
- *
- * Counts how many Tab Out pages are open. If more than 1,
- * shows a banner offering to close the extras.
- */
-function checkTabOutDupes() {
-  const tabOutTabs = openTabs.filter(t => t.isTabOut);
-  const banner  = document.getElementById('tabOutDupeBanner');
-  const countEl = document.getElementById('tabOutDupeCount');
-  if (!banner) return;
-
-  if (tabOutTabs.length > 1) {
-    if (countEl) countEl.textContent = tabOutTabs.length;
-    banner.style.display = 'flex';
-  } else {
-    banner.style.display = 'none';
-  }
-}
 
 
 /* ----------------------------------------------------------------
@@ -1646,9 +1600,6 @@ async function renderStaticDashboard() {
     openTabsSection.style.display = 'none';
   }
 
-  // --- Check for duplicate Tab Out tabs ---
-  checkTabOutDupes();
-
   // --- Render "Saved for Later" column ---
   await renderDeferredColumn();
 }
@@ -1720,20 +1671,6 @@ document.addEventListener('click', async (e) => {
   if (action === 'close-icon-picker') {
     e.stopPropagation();
     closeIconPicker();
-    return;
-  }
-
-  // ---- Close duplicate Tab Out tabs ----
-  if (action === 'close-tabout-dupes') {
-    await closeTabOutDupes();
-    playCloseSound();
-    const banner = document.getElementById('tabOutDupeBanner');
-    if (banner) {
-      banner.style.transition = 'opacity 0.4s';
-      banner.style.opacity = '0';
-      setTimeout(() => { banner.style.display = 'none'; banner.style.opacity = '1'; }, 400);
-    }
-    showToast('Closed extra Tab Out tabs');
     return;
   }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,5 +1,5 @@
 /**
- * background.js — Service Worker for Badge Updates
+ * background.js — Service Worker for Badge Updates + Toolbar Launcher
  *
  * Chrome's "always-on" background script for Tab Out.
  * Its only job: keep the toolbar badge showing the current open tab count.
@@ -85,6 +85,46 @@ chrome.tabs.onRemoved.addListener(() => {
 // Update badge when a tab's URL changes (e.g. navigating to/from chrome://)
 chrome.tabs.onUpdated.addListener(() => {
   updateBadge();
+});
+
+// ─── Toolbar icon launcher ────────────────────────────────────────────────────
+//
+// Clicking the Tab Out icon opens the dashboard as a fresh tab right next to
+// wherever the user currently is. Any pre-existing Tab Out tab (in this or
+// any other window/workspace) is closed first — we never keep stale copies.
+chrome.action.onClicked.addListener(async () => {
+  const newtabUrl = chrome.runtime.getURL("index.html");
+
+  try {
+    const [activeTab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+    // If the user is already ON a Tab Out tab, just reload it — no need to
+    // close/recreate (would be destructive if it's the only tab in the window).
+    if (activeTab && activeTab.url === newtabUrl) {
+      await chrome.tabs.reload(activeTab.id);
+      return;
+    }
+
+    // Close any stale Tab Out copies elsewhere so only one ever exists.
+    const allTabs = await chrome.tabs.query({});
+    const stale   = allTabs.filter(t => t.url === newtabUrl);
+    if (stale.length > 0) {
+      await chrome.tabs.remove(stale.map(t => t.id));
+    }
+
+    // Open a fresh Tab Out tab in the current window, right after the active
+    // tab, in the active workspace (inherits workspace via index on Opera GX).
+    const createOpts = { url: newtabUrl, active: true };
+    if (activeTab) {
+      createOpts.windowId = activeTab.windowId;
+      if (typeof activeTab.index === 'number') createOpts.index = activeTab.index + 1;
+      if (activeTab.workspaceId) createOpts.workspaceId = activeTab.workspaceId;
+    }
+    await chrome.tabs.create(createOpts);
+  } catch (err) {
+    // Fallback: just create one somewhere
+    chrome.tabs.create({ url: newtabUrl });
+  }
 });
 
 // ─── Initial run ─────────────────────────────────────────────────────────────

--- a/extension/index.html
+++ b/extension/index.html
@@ -47,6 +47,32 @@
   </div>
 
   <!-- ================================================================
+       GLOBAL SEARCH BAR
+       ================================================================ -->
+  <div class="search-bar-wrap" id="searchBarWrap">
+    <span class="search-bar-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"/>
+      </svg>
+    </span>
+    <input type="text" class="search-bar" id="searchBar" placeholder="Search tabs, saved items, folders…">
+    <button class="search-clear-btn" id="searchClearBtn" title="Clear search">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2.5" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12"/>
+      </svg>
+    </button>
+  </div>
+
+  <!-- ================================================================
+       FOLDER BAR — global folder chips + management panel
+       Rendered by renderFolderBar() in app.js; hidden when no folders exist
+       ================================================================ -->
+  <div class="folder-bar-wrap" id="folderBarWrap" style="display:none">
+    <div class="folder-bar" id="folderBar"></div>
+    <div class="folder-manage-panel" id="folderManagePanel" style="display:none"></div>
+  </div>
+
+  <!-- ================================================================
        MAIN CONTENT AREA — two-column layout
        Left: open tabs (domain/mission cards)
        Right: saved for later checklist
@@ -60,6 +86,10 @@
         <h2 id="openTabsSectionTitle">Right now</h2>
         <div class="section-line"></div>
         <div class="section-count" id="openTabsSectionCount"></div>
+        <button class="new-folder-btn" data-action="new-folder" data-section="open" title="New folder">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/></svg>
+          Folder
+        </button>
       </div>
       <!-- Opera GX workspace filter — populated by renderStaticDashboard() when ≥2 workspaces detected -->
       <div class="workspace-filter" id="workspaceFilter" style="display:none"></div>
@@ -72,6 +102,10 @@
         <h2>Saved for later</h2>
         <div class="section-line"></div>
         <div class="section-count" id="deferredCount"></div>
+        <button class="new-folder-btn" data-action="new-folder" data-section="saved" title="New folder">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15"/></svg>
+          Folder
+        </button>
       </div>
 
       <!-- Active checklist items — injected by renderDeferredList() in app.js -->

--- a/extension/index.html
+++ b/extension/index.html
@@ -29,24 +29,6 @@
   </header>
 
   <!-- ================================================================
-       TAB OUT DUPES BANNER — appears when you have extra Tab Out tabs open
-       Hidden by default; app.js shows it when dupeTabOutCount > 1
-       ================================================================ -->
-  <div class="tab-cleanup-banner" id="tabOutDupeBanner" style="display:none">
-    <div class="tab-cleanup-left">
-      <div class="tab-cleanup-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75" />
-        </svg>
-      </div>
-      <div class="tab-cleanup-text">
-        You have <strong id="tabOutDupeCount"></strong> Tab Out tabs open. Keep just this one?
-      </div>
-    </div>
-    <button class="tab-cleanup-btn" data-action="close-tabout-dupes">Close extras</button>
-  </div>
-
-  <!-- ================================================================
        MAIN CONTENT AREA — two-column layout
        Left: open tabs (domain/mission cards)
        Right: saved for later checklist

--- a/extension/index.html
+++ b/extension/index.html
@@ -61,6 +61,8 @@
         <div class="section-line"></div>
         <div class="section-count" id="openTabsSectionCount"></div>
       </div>
+      <!-- Opera GX workspace filter — populated by renderStaticDashboard() when ≥2 workspaces detected -->
+      <div class="workspace-filter" id="workspaceFilter" style="display:none"></div>
       <div class="missions" id="openTabsMissions"></div>
     </div>
 
@@ -97,21 +99,22 @@
   </div><!-- end .dashboard-columns -->
 
   <!-- ================================================================
-       FOOTER — global stats + refresh control
+       FOOTER — attribution only (tab/domain counts moved to section header)
        ================================================================ -->
   <footer>
-    <div class="footer-stats">
-      <div class="stat">
-        <div class="stat-num" id="statTabs">—</div>
-        <div class="stat-label">Open tabs</div>
-      </div>
-    </div>
     <div class="last-refresh">
       <span style="color: var(--muted); font-size: 11px;"><a href="https://github.com/zarazhangrui/tab-out" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Tab Out</a> by <a href="https://x.com/zarazhangrui" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Zara</a></span>
     </div>
   </footer>
 
 </div><!-- end .container -->
+
+<!-- ================================================================
+     ICON PICKER — workspace filter emoji selector
+     Positioned absolutely under the clicked workspace when opened;
+     contents rendered by app.js on open.
+     ================================================================ -->
+<div class="icon-picker" id="iconPicker" style="display:none"></div>
 
 <!-- ================================================================
      TOAST — floats above everything, used for action confirmations
@@ -124,10 +127,6 @@
   </svg>
   <span id="toastText"></span>
 </div>
-
-<!-- Personal config (gitignored) — defines LOCAL_LANDING_PAGE_PATTERNS etc. -->
-<!-- If the file doesn't exist, that's fine — app.js uses sensible defaults. -->
-<script src="config.local.js" onerror="/* no personal config, that's fine */"></script>
 
 <!-- Main dashboard logic — loads last so the DOM is ready -->
 <script src="app.js"></script>

--- a/extension/index.html
+++ b/extension/index.html
@@ -29,6 +29,24 @@
   </header>
 
   <!-- ================================================================
+       TAB OUT DUPES BANNER — appears when you have extra Tab Out tabs open
+       Hidden by default; app.js shows it when dupeTabOutCount > 1
+       ================================================================ -->
+  <div class="tab-cleanup-banner" id="tabOutDupeBanner" style="display:none">
+    <div class="tab-cleanup-left">
+      <div class="tab-cleanup-icon">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75" />
+        </svg>
+      </div>
+      <div class="tab-cleanup-text">
+        You have <strong id="tabOutDupeCount"></strong> Tab Out tabs open. Keep just this one?
+      </div>
+    </div>
+    <button class="tab-cleanup-btn" data-action="close-tabout-dupes">Close extras</button>
+  </div>
+
+  <!-- ================================================================
        MAIN CONTENT AREA — two-column layout
        Left: open tabs (domain/mission cards)
        Right: saved for later checklist

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,7 +4,6 @@
   "version": "1.0.0",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
   "permissions": ["tabs", "activeTab", "storage"],
-  "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },
   "action": {
     "default_title": "Tab Out",

--- a/extension/style.css
+++ b/extension/style.css
@@ -1636,6 +1636,521 @@ img.workspace-btn-icon {
   color: var(--accent-amber);
 }
 
+/* ================================================================
+   FOLDERS — open-tab and saved-item organisation
+   ================================================================ */
+
+/* Folder header card — spans all columns in the .missions grid */
+.tab-folder-header-card {
+  column-span: all;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 7px 4px 5px;
+  margin-top: 10px;
+  cursor: pointer;
+  user-select: none;
+  border-radius: 6px;
+  transition: background 0.15s;
+  break-inside: avoid;
+}
+.tab-folder-header-card:first-child { margin-top: 0; }
+.tab-folder-header-card:hover { background: rgba(154,145,138,0.06); }
+
+.tab-folder-chevron {
+  width: 12px; height: 12px;
+  color: var(--muted);
+  transition: transform 0.2s;
+  flex-shrink: 0;
+}
+.tab-folder-header-card.collapsed .tab-folder-chevron { transform: rotate(-90deg); }
+
+.tab-folder-name {
+  font-size: 13px; font-weight: 600;
+  color: var(--ink); flex: 1;
+}
+.tab-folder-name-input {
+  font-size: 13px; font-weight: 600;
+  font-family: 'DM Sans', sans-serif;
+  background: none; border: none;
+  border-bottom: 1.5px solid var(--accent-amber);
+  outline: none; color: var(--ink); flex: 1; padding: 0;
+}
+
+.tab-folder-count {
+  font-size: 10px; color: var(--muted);
+  background: rgba(154,145,138,0.1);
+  padding: 1px 5px; border-radius: 3px;
+}
+
+.tab-folder-updated { font-size: 10px; color: var(--muted); font-style: italic; }
+
+.tab-folder-actions {
+  display: flex; gap: 1px;
+  opacity: 0; transition: opacity 0.15s;
+}
+.tab-folder-header-card:hover .tab-folder-actions { opacity: 1; }
+
+.tab-folder-btn {
+  background: none; border: none; cursor: pointer;
+  color: var(--muted); padding: 3px; border-radius: 4px;
+  display: flex; align-items: center;
+  transition: background 0.15s, color 0.15s;
+}
+.tab-folder-btn:hover { background: rgba(154,145,138,0.15); color: var(--ink); }
+.tab-folder-btn.danger:hover { color: var(--status-abandoned); }
+.tab-folder-btn svg { width: 12px; height: 12px; }
+
+/* Unfiled separator — also spans all columns */
+.tab-unfiled-sep {
+  column-span: all;
+  display: flex; align-items: center; gap: 8px;
+  margin: 14px 0 4px;
+  break-inside: avoid;
+}
+.tab-unfiled-label {
+  font-size: 10px; color: var(--muted);
+  text-transform: uppercase; letter-spacing: 0.8px;
+  font-weight: 500; white-space: nowrap;
+}
+.tab-unfiled-line { flex: 1; height: 1px; background: var(--warm-gray); }
+
+/* Cards whose folder is collapsed are hidden */
+.mission-card.folder-hidden { display: none !important; }
+
+/* New-folder button */
+.new-folder-btn {
+  background: none;
+  border: 1px dashed rgba(154,145,138,0.5);
+  border-radius: 4px; color: var(--muted);
+  font-size: 11px; font-family: 'DM Sans', sans-serif;
+  padding: 3px 8px; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 4px;
+  transition: all 0.15s;
+}
+.new-folder-btn:hover { border-color: var(--ink); color: var(--ink); }
+.new-folder-btn svg { width: 11px; height: 11px; }
+
+/* Move-to-folder button on domain cards */
+.move-folder-btn {
+  background: none; border: none; cursor: pointer;
+  color: var(--muted); padding: 4px; opacity: 0.35;
+  transition: opacity 0.15s, color 0.15s;
+  display: inline-flex; align-items: center; font-size: 11px;
+  font-family: 'DM Sans', sans-serif; gap: 3px;
+}
+.move-folder-btn svg { width: 12px; height: 12px; }
+.move-folder-btn:hover { opacity: 1; color: var(--accent-slate); }
+.move-folder-btn.in-folder { opacity: 0.9; color: var(--accent-slate); }
+
+/* Domain card reorder buttons */
+.card-reorder-btns {
+  display: flex; gap: 2px;
+  opacity: 0; transition: opacity 0.15s;
+}
+.mission-card:hover .card-reorder-btns { opacity: 0.55; }
+.card-reorder-btn {
+  background: none; border: none; cursor: pointer;
+  color: var(--muted); padding: 3px 2px; border-radius: 3px;
+  display: flex; align-items: center; transition: color 0.1s;
+  font-size: 10px;
+}
+.card-reorder-btn:hover { color: var(--ink); }
+.card-reorder-btn svg { width: 11px; height: 11px; }
+
+/* Saved-column folder wrapper */
+.saved-folder { margin-bottom: 8px; }
+
+.saved-folder-header {
+  display: flex; align-items: center; gap: 6px;
+  padding: 6px 8px; cursor: pointer;
+  border-radius: 6px; transition: background 0.15s;
+  user-select: none;
+}
+.saved-folder-header:hover { background: rgba(154,145,138,0.06); }
+
+.saved-folder-chevron {
+  width: 11px; height: 11px; color: var(--muted);
+  transition: transform 0.2s; flex-shrink: 0;
+}
+.saved-folder.collapsed .saved-folder-chevron { transform: rotate(-90deg); }
+
+.saved-folder-name {
+  font-size: 12px; font-weight: 600;
+  color: var(--ink); flex: 1;
+}
+.saved-folder-name-input {
+  font-size: 12px; font-weight: 600;
+  font-family: 'DM Sans', sans-serif;
+  background: none; border: none;
+  border-bottom: 1.5px solid var(--accent-amber);
+  outline: none; color: var(--ink); flex: 1; padding: 0;
+}
+
+.saved-folder-meta {
+  font-size: 10px; color: var(--muted);
+  display: flex; align-items: center; gap: 5px;
+}
+
+.saved-folder-actions {
+  display: flex; gap: 1px;
+  opacity: 0; transition: opacity 0.15s;
+}
+.saved-folder-header:hover .saved-folder-actions { opacity: 1; }
+
+.saved-folder-btn {
+  background: none; border: none; cursor: pointer;
+  color: var(--muted); padding: 2px; border-radius: 3px;
+  display: flex; transition: background 0.1s, color 0.1s;
+}
+.saved-folder-btn:hover { background: rgba(154,145,138,0.15); color: var(--ink); }
+.saved-folder-btn.danger:hover { color: var(--status-abandoned); }
+.saved-folder-btn svg { width: 11px; height: 11px; }
+
+.saved-folder-body { padding: 2px 0 2px 4px; }
+.saved-folder.collapsed .saved-folder-body { display: none; }
+
+/* Unfiled separator in saved column */
+.saved-unfiled-sep {
+  display: flex; align-items: center; gap: 8px;
+  margin: 10px 4px 6px;
+}
+.saved-unfiled-label {
+  font-size: 10px; color: var(--muted);
+  text-transform: uppercase; letter-spacing: 0.8px;
+  font-weight: 500; white-space: nowrap;
+}
+.saved-unfiled-line { flex: 1; height: 1px; background: var(--warm-gray); }
+
+/* Reorder up/down on saved items */
+.reorder-btns {
+  display: flex; flex-direction: column; gap: 0;
+  opacity: 0; transition: opacity 0.15s; flex-shrink: 0;
+}
+.deferred-item:hover .reorder-btns { opacity: 0.5; }
+.deferred-group:hover > .group-header .reorder-btns { opacity: 0.5; }
+
+.reorder-btn {
+  background: none; border: none; cursor: pointer;
+  color: var(--muted); padding: 1px 2px;
+  display: flex; align-items: center; transition: color 0.1s;
+}
+.reorder-btn:hover { color: var(--ink); }
+.reorder-btn svg { width: 10px; height: 10px; }
+
+/* Move-to-folder button on saved items */
+.item-folder-btn {
+  background: none; border: none; cursor: pointer;
+  color: var(--muted); padding: 2px; opacity: 0.35;
+  transition: opacity 0.15s, color 0.15s;
+  display: flex; align-items: center; flex-shrink: 0;
+}
+.item-folder-btn svg { width: 13px; height: 13px; }
+.item-folder-btn:hover { opacity: 1; color: var(--accent-slate); }
+.item-folder-btn.in-folder { opacity: 0.9; color: var(--accent-slate); }
+
+/* Folder picker dropdown */
+.folder-picker {
+  position: fixed;
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray);
+  border-radius: 8px;
+  box-shadow: 0 6px 24px rgba(26,22,19,0.14);
+  z-index: 500; min-width: 180px; padding: 4px;
+}
+.folder-picker-item {
+  display: flex; align-items: center; gap: 7px;
+  width: 100%; background: none; border: none;
+  padding: 8px 10px;
+  font-family: 'DM Sans', sans-serif; font-size: 12px;
+  color: var(--ink); cursor: pointer; border-radius: 5px;
+  text-align: left; transition: background 0.1s;
+}
+.folder-picker-item:hover { background: rgba(154,145,138,0.1); }
+.folder-picker-item.current { color: var(--accent-sage); font-weight: 600; }
+.folder-picker-sep { height: 1px; background: var(--warm-gray); margin: 3px 6px; }
+
+/* Drag-and-drop drop target */
+.drop-target { outline: 2px dashed var(--accent-amber); outline-offset: 3px; border-radius: 8px; }
+
+/* ================================================================
+   SEARCH BAR
+   ================================================================ */
+.search-bar-wrap {
+  position: relative; margin-bottom: 28px;
+}
+.search-bar {
+  width: 100%;
+  padding: 10px 36px 10px 38px;
+  font-family: 'DM Sans', sans-serif; font-size: 13px;
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray); border-radius: 8px;
+  color: var(--ink); outline: none;
+  transition: border-color 0.2s;
+}
+.search-bar:focus { border-color: var(--accent-amber); }
+.search-bar::placeholder { color: var(--muted); }
+
+.search-bar-icon {
+  position: absolute; left: 12px; top: 50%;
+  transform: translateY(-50%);
+  color: var(--muted); pointer-events: none; display: flex;
+}
+.search-bar-icon svg { width: 15px; height: 15px; }
+
+.search-clear-btn {
+  position: absolute; right: 10px; top: 50%;
+  transform: translateY(-50%);
+  background: none; border: none; cursor: pointer;
+  color: var(--muted); padding: 3px; border-radius: 3px;
+  display: none; align-items: center;
+  transition: color 0.15s;
+}
+.search-bar-wrap.has-query .search-clear-btn { display: flex; }
+.search-clear-btn:hover { color: var(--ink); }
+.search-clear-btn svg { width: 12px; height: 12px; }
+
+mark.search-hit {
+  background: rgba(200,113,58,0.18); color: inherit;
+  border-radius: 2px; padding: 0 1px;
+}
+
+/* ================================================================
+   FOLDER BAR — global chip strip at the top of the content area
+   ================================================================ */
+
+.folder-bar-wrap {
+  margin-bottom: 20px;
+}
+
+.folder-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+}
+
+/* Base chip */
+.folder-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 13px;
+  border-radius: 20px;
+  border: 1.5px solid var(--warm-gray);
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  font-family: 'DM Sans', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s, background 0.15s,
+              padding 0.2s ease, font-size 0.2s ease, box-shadow 0.2s ease;
+}
+
+.folder-chip svg {
+  width: 14px; height: 14px;
+  flex-shrink: 0;
+  transition: width 0.2s, height 0.2s;
+}
+
+.folder-chip:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+/* Active (selected) chip — noticeably bigger */
+.folder-chip.active {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+  padding: 9px 20px;
+  font-size: 14px;
+  font-weight: 600;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.25);
+}
+
+.folder-chip.active svg {
+  width: 17px; height: 17px;
+}
+
+/* "New folder" chip — dashed outline */
+.folder-chip-new {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 12px;
+  border-radius: 20px;
+  border: 1.5px dashed var(--warm-gray);
+  background: transparent;
+  color: var(--muted);
+  font-size: 12px;
+  font-family: 'DM Sans', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s;
+}
+
+.folder-chip-new svg {
+  width: 12px; height: 12px;
+}
+
+.folder-chip-new:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+/* Spacer pushes "New folder" + "Manage" to the right */
+.folder-bar-spacer {
+  flex: 1;
+}
+
+/* Manage button */
+.folder-manage-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 5px 11px;
+  border-radius: 20px;
+  border: 1.5px solid var(--warm-gray);
+  background: transparent;
+  color: var(--muted);
+  font-size: 11px;
+  font-family: 'DM Sans', sans-serif;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.folder-manage-toggle svg {
+  width: 13px; height: 13px;
+}
+
+.folder-manage-toggle:hover,
+.folder-manage-toggle.open {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+.folder-manage-toggle.open {
+  background: rgba(154,145,138,0.08);
+}
+
+/* ================================================================
+   FOLDER MANAGEMENT PANEL — collapsible list below the bar
+   ================================================================ */
+
+.folder-manage-panel {
+  margin-top: 10px;
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray);
+  border-radius: 10px;
+  padding: 6px 10px;
+}
+
+.folder-manage-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.folder-manage-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 8px;
+  border-radius: 7px;
+  transition: background 0.12s;
+}
+
+.folder-manage-row:hover {
+  background: rgba(154,145,138,0.06);
+}
+
+.folder-manage-icon {
+  flex-shrink: 0;
+  display: flex;
+  color: var(--muted);
+}
+
+.folder-manage-icon svg {
+  width: 16px; height: 16px;
+}
+
+.folder-manage-name {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--ink);
+  min-width: 0;
+}
+
+.folder-manage-name-input {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: 'DM Sans', sans-serif;
+  background: none;
+  border: none;
+  border-bottom: 1.5px solid var(--accent-amber);
+  outline: none;
+  color: var(--ink);
+  padding: 0;
+  min-width: 0;
+}
+
+.folder-manage-btns {
+  display: flex;
+  gap: 2px;
+  flex-shrink: 0;
+}
+
+.folder-manage-btns button {
+  width: 28px; height: 28px;
+  display: flex; align-items: center; justify-content: center;
+  background: none;
+  border: none;
+  border-radius: 5px;
+  color: var(--muted);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+}
+
+.folder-manage-btns button:hover {
+  background: rgba(154,145,138,0.15);
+  color: var(--ink);
+}
+
+.folder-manage-btns button.danger:hover {
+  background: rgba(179,90,90,0.12);
+  color: var(--accent-rose);
+}
+
+.folder-manage-btns button svg {
+  width: 14px; height: 14px;
+}
+
+/* Empty state shown in the grid/list when a folder has no content */
+.folder-empty-state {
+  column-span: all;
+  font-size: 13px;
+  color: var(--muted);
+  padding: 24px 0 8px;
+  font-style: italic;
+}
+
+/* ================================================================
+   FOLDER ICON SIZE FIXES — increase from the previous too-small sizes
+   ================================================================ */
+
+.tab-folder-btn svg       { width: 15px !important; height: 15px !important; }
+.saved-folder-btn svg     { width: 14px !important; height: 14px !important; }
+.move-folder-btn svg      { width: 15px !important; height: 15px !important; }
+.item-folder-btn svg      { width: 15px !important; height: 15px !important; }
+.tab-folder-chevron       { width: 14px !important; height: 14px !important; }
+.saved-folder-chevron     { width: 13px !important; height: 13px !important; }
+.folder-picker-item svg   { width: 14px !important; height: 14px !important; }
+
 /* ---- Dark Mode ---- */
 :root {
   --ink: #e8e2da;

--- a/extension/style.css
+++ b/extension/style.css
@@ -604,34 +604,8 @@ footer {
   padding-top: 20px;
   border-top: 1px solid var(--warm-gray);
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
-}
-
-.footer-stats {
-  display: flex;
-  gap: 32px;
-}
-
-.stat {
-  text-align: center;
-}
-
-.stat-num {
-  font-family: 'Newsreader', serif;
-  font-size: 28px;
-  font-weight: 300;
-  color: var(--ink);
-  line-height: 1;
-  transition: all 0.3s;
-}
-
-.stat-label {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 1.5px;
-  color: var(--muted);
-  margin-top: 4px;
 }
 
 .last-refresh {
@@ -1035,6 +1009,29 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   color: var(--status-abandoned);
 }
 
+/* Restore (reopen) button — same footprint as dismiss, sage hover */
+.deferred-restore {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 2px;
+  opacity: 0.3;
+  transition: opacity 0.15s, color 0.15s;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.deferred-restore svg {
+  width: 14px;
+  height: 14px;
+}
+
+.deferred-restore:hover {
+  opacity: 1;
+  color: var(--accent-sage);
+}
+
 /* Slide-out animation for items being removed */
 .deferred-item.removing {
   opacity: 0;
@@ -1155,4 +1152,522 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   color: var(--muted);
   opacity: 0.6;
   flex-shrink: 0;
+}
+
+.archive-restore {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 2px;
+  opacity: 0;
+  transition: opacity 0.15s, color 0.15s;
+  flex-shrink: 0;
+}
+
+.archive-restore svg {
+  width: 13px;
+  height: 13px;
+}
+
+.archive-item:hover .archive-restore {
+  opacity: 0.5;
+}
+
+.archive-restore:hover {
+  opacity: 1 !important;
+  color: var(--accent-sage);
+}
+
+/* ---- Saved / Archived GROUPS (collapsible multi-tab bundles) ---- */
+.deferred-group {
+  border: 1px solid var(--warm-gray);
+  border-radius: 8px;
+  background: var(--card-bg);
+  margin-bottom: 8px;
+  overflow: hidden;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.deferred-group.removing {
+  opacity: 0;
+  transform: translateX(20px);
+}
+
+.group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  cursor: default;
+}
+
+.deferred-group:not(.collapsed) .group-header {
+  border-bottom: 1px solid rgba(154, 145, 138, 0.12);
+}
+
+.group-toggle {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: color 0.15s;
+}
+
+.group-toggle svg {
+  width: 14px;
+  height: 14px;
+  transition: transform 0.2s ease;
+}
+
+.deferred-group.collapsed .group-chevron {
+  transform: rotate(-90deg);
+}
+
+.group-toggle:hover { color: var(--ink); }
+
+.group-header-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.group-header-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--ink);
+  overflow: hidden;
+}
+
+.group-header-favicon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.group-header-label {
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.group-header-count {
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 400;
+  flex-shrink: 0;
+}
+
+.group-header-meta {
+  font-size: 10px;
+  color: var(--muted);
+  margin-top: 1px;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+/* Workspace badge inside the group's meta line */
+.group-ws-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(200, 113, 58, 0.10);
+  border: 1px solid rgba(200, 113, 58, 0.25);
+  color: var(--accent-amber);
+  font-weight: 500;
+  font-size: 10px;
+  line-height: 1.4;
+}
+
+.group-ws-badge.multi {
+  background: rgba(154, 145, 138, 0.10);
+  border-color: rgba(154, 145, 138, 0.25);
+  color: var(--muted);
+}
+
+.group-ws-badge.deleted {
+  background: rgba(179, 90, 90, 0.08);
+  border-color: rgba(179, 90, 90, 0.25);
+  color: var(--status-abandoned);
+  text-decoration: line-through;
+  text-decoration-thickness: 1px;
+  opacity: 0.85;
+}
+
+.group-ws-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  line-height: 1;
+}
+
+.group-meta-dot {
+  opacity: 0.6;
+}
+
+.group-header-action {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.45;
+  flex-shrink: 0;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.group-header-action svg {
+  width: 14px;
+  height: 14px;
+}
+
+.group-header:hover .group-header-action {
+  opacity: 0.8;
+}
+
+.group-header-action:hover {
+  opacity: 1 !important;
+  color: var(--accent-sage);
+}
+
+.group-header-action.group-check:hover {
+  color: var(--accent-amber);
+}
+
+.group-header-action[data-action="dismiss-group"]:hover {
+  color: var(--status-abandoned);
+}
+
+/* Group body — list of items, collapsed when .collapsed set on group */
+.group-body {
+  padding: 4px 8px 8px 30px;
+  transition: max-height 0.2s ease;
+}
+
+.deferred-group.collapsed .group-body {
+  display: none;
+}
+
+.group-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 0;
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+
+.group-item.removing {
+  opacity: 0;
+  transform: translateX(16px);
+}
+
+.group-item-title {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink);
+  text-decoration: none;
+  font-size: 12px;
+  overflow: hidden;
+  transition: color 0.15s;
+}
+
+.group-item-title:hover {
+  color: var(--accent-amber);
+}
+
+.group-item-favicon {
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+
+.group-item-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+
+.group-item.archived .group-item-title {
+  color: var(--muted);
+}
+
+/* Tighter button footprints inside group body */
+.group-item .deferred-restore,
+.group-item .deferred-dismiss {
+  margin-top: 0;
+}
+
+.group-item .deferred-restore svg,
+.group-item .deferred-dismiss svg {
+  width: 12px;
+  height: 12px;
+}
+
+/* ---- Workspace filter bar (Opera GX) ---- */
+.workspace-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: -4px;
+  margin-bottom: 20px;
+}
+
+.workspace-btn {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 5px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--warm-gray);
+  background: var(--card-bg);
+  color: var(--muted);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.workspace-btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  line-height: 1;
+  width: 14px;
+  height: 14px;
+}
+
+img.workspace-btn-icon {
+  object-fit: contain;
+}
+
+/* Wrap around each workspace pill so we can overlay an edit pencil
+   in the corner without breaking the pill's click target. */
+.workspace-btn-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.workspace-btn-edit {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid var(--warm-gray);
+  background: var(--card-bg);
+  color: var(--muted);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(0.8);
+  transition: opacity 0.15s, transform 0.15s, border-color 0.15s, color 0.15s;
+  pointer-events: none;
+}
+
+.workspace-btn-edit svg {
+  width: 10px;
+  height: 10px;
+}
+
+.workspace-btn-wrap:hover .workspace-btn-edit,
+.workspace-btn-edit:focus-visible {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.workspace-btn-edit:hover {
+  border-color: var(--accent-amber);
+  color: var(--accent-amber);
+}
+
+/* ---- Icon picker popover ---- */
+.icon-picker {
+  position: absolute;
+  z-index: 1000;
+  width: 320px;
+  max-height: 440px;
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px var(--shadow), 0 2px 6px var(--shadow);
+  font-family: 'DM Sans', sans-serif;
+  color: var(--ink);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.icon-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  font-size: 12px;
+  color: var(--muted);
+  border-bottom: 1px solid var(--warm-gray);
+}
+
+.icon-picker-header strong {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.icon-picker-close {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s;
+}
+
+.icon-picker-close svg {
+  width: 14px;
+  height: 14px;
+}
+
+.icon-picker-close:hover {
+  color: var(--ink);
+}
+
+.icon-picker-body {
+  overflow-y: auto;
+  padding: 6px 8px 10px;
+  flex: 1;
+}
+
+.icon-picker-section {
+  margin-top: 6px;
+}
+
+.icon-picker-section-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--muted);
+  padding: 6px 4px 4px;
+}
+
+.icon-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 2px;
+}
+
+.icon-picker-option {
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 4px 0;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.1s, border-color 0.1s, transform 0.1s;
+}
+
+.icon-picker-option:hover {
+  background: rgba(200, 113, 58, 0.1);
+  border-color: var(--accent-amber);
+  transform: scale(1.1);
+}
+
+.icon-picker-footer {
+  display: flex;
+  gap: 6px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--warm-gray);
+  background: var(--card-bg);
+}
+
+.icon-picker-input {
+  flex: 1;
+  min-width: 0;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--warm-gray);
+  background: var(--paper);
+  color: var(--ink);
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.icon-picker-input:focus {
+  border-color: var(--accent-amber);
+}
+
+.icon-picker-input::placeholder {
+  color: var(--muted);
+}
+
+.icon-picker-clear {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--warm-gray);
+  background: var(--card-bg);
+  color: var(--muted);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s;
+}
+
+.icon-picker-clear:hover {
+  border-color: var(--status-abandoned);
+  color: var(--status-abandoned);
+}
+
+.workspace-btn:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+.workspace-btn.active {
+  background: rgba(200, 113, 58, 0.12);
+  border-color: var(--accent-amber);
+  color: var(--accent-amber);
+}
+
+/* ---- Dark Mode ---- */
+:root {
+  --ink: #e8e2da;
+  --paper: #1a1613;
+  --warm-gray: #2e2a26;
+  --muted: #8a817a;
+  --card-bg: #242019;
+  --shadow: rgba(0, 0, 0, 0.3);
 }

--- a/extension/style.css
+++ b/extension/style.css
@@ -231,7 +231,7 @@ header {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  transition: box-shadow 0.25s ease, transform 0.25s ease;
+  transition: box-shadow 0.25s ease, transform 0.25s ease, opacity 0.3s ease;
   cursor: pointer;
   position: relative;
   overflow: hidden;
@@ -534,14 +534,14 @@ header {
 }
 
 .action-btn.close-tabs {
-  border-color: rgba(200, 113, 58, 0.3);
-  color: var(--accent-amber);
-  background: rgba(200, 113, 58, 0.04);
+  border-color: rgba(179, 90, 90, 0.3);
+  color: var(--status-abandoned);
+  background: rgba(179, 90, 90, 0.04);
 }
 
 .action-btn.close-tabs:hover {
-  background: rgba(200, 113, 58, 0.1);
-  border-color: var(--accent-amber);
+  background: rgba(179, 90, 90, 0.1);
+  border-color: var(--status-abandoned);
 }
 
 .action-btn.save-tabs {
@@ -553,6 +553,17 @@ header {
 .action-btn.save-tabs:hover {
   background: rgba(90, 122, 98, 0.1);
   border-color: var(--accent-sage);
+}
+
+.action-btn.archive-tabs {
+  border-color: rgba(200, 113, 58, 0.3);
+  color: var(--accent-amber);
+  background: rgba(200, 113, 58, 0.04);
+}
+
+.action-btn.archive-tabs:hover {
+  background: rgba(200, 113, 58, 0.1);
+  border-color: var(--accent-amber);
 }
 
 .action-btn.danger {
@@ -901,50 +912,16 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   display: flex;
   align-items: flex-start;
   gap: 10px;
-  padding: 10px 0;
-  border-bottom: 1px solid rgba(154, 145, 138, 0.12);
+  padding: 10px 12px;
+  border: 1px solid var(--warm-gray);
+  border-radius: 8px;
+  background: var(--card-bg);
+  margin-bottom: 6px;
   animation: fadeUp 0.3s ease both;
 }
 
 .deferred-item:last-child {
-  border-bottom: none;
-}
-
-/* Custom checkbox */
-.deferred-checkbox {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 18px;
-  height: 18px;
-  border: 2px solid var(--warm-gray);
-  border-radius: 4px;
-  cursor: pointer;
-  flex-shrink: 0;
-  margin-top: 1px;
-  transition: all 0.2s;
-  position: relative;
-}
-
-.deferred-checkbox:hover {
-  border-color: var(--accent-sage);
-}
-
-.deferred-checkbox:checked {
-  background: var(--accent-sage);
-  border-color: var(--accent-sage);
-}
-
-/* Checkmark inside the checkbox */
-.deferred-checkbox:checked::after {
-  content: '';
-  position: absolute;
-  top: 2px;
-  left: 5px;
-  width: 4px;
-  height: 8px;
-  border: solid white;
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg);
+  margin-bottom: 0;
 }
 
 /* Item content (title, domain, time) */
@@ -976,25 +953,15 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   gap: 8px;
 }
 
-/* Checked-off item — strikethrough + faded */
-.deferred-item.checked .deferred-title {
-  text-decoration: line-through;
-  color: var(--muted);
-}
-
-.deferred-item.checked .deferred-meta {
-  opacity: 0.5;
-}
-
-/* Dismiss (X) button */
+/* Dismiss (X) button — rose/red */
 .deferred-dismiss {
   background: none;
   border: none;
-  color: var(--muted);
+  color: var(--status-abandoned);
   cursor: pointer;
   padding: 2px;
-  opacity: 0.3;
-  transition: opacity 0.15s, color 0.15s;
+  opacity: 0.5;
+  transition: opacity 0.15s;
   flex-shrink: 0;
   margin-top: 1px;
 }
@@ -1006,17 +973,16 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 
 .deferred-dismiss:hover {
   opacity: 1;
-  color: var(--status-abandoned);
 }
 
-/* Restore (reopen) button — same footprint as dismiss, sage hover */
+/* Restore (reopen) button — sage green */
 .deferred-restore {
   background: none;
   border: none;
-  color: var(--muted);
+  color: var(--accent-sage);
   cursor: pointer;
   padding: 2px;
-  opacity: 0.3;
+  opacity: 0.55;
   transition: opacity 0.15s, color 0.15s;
   flex-shrink: 0;
   margin-top: 1px;
@@ -1157,11 +1123,11 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 .archive-restore {
   background: none;
   border: none;
-  color: var(--muted);
+  color: var(--accent-sage);
   cursor: pointer;
   padding: 2px;
-  opacity: 0;
-  transition: opacity 0.15s, color 0.15s;
+  opacity: 0.45;
+  transition: opacity 0.15s;
   flex-shrink: 0;
 }
 
@@ -1170,13 +1136,8 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   height: 13px;
 }
 
-.archive-item:hover .archive-restore {
-  opacity: 0.5;
-}
-
 .archive-restore:hover {
-  opacity: 1 !important;
-  color: var(--accent-sage);
+  opacity: 1;
 }
 
 /* ---- Saved / Archived GROUPS (collapsible multi-tab bundles) ---- */
@@ -1320,15 +1281,13 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 .group-header-action {
   background: none;
   border: none;
-  color: var(--muted);
   cursor: pointer;
   padding: 3px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  opacity: 0.45;
   flex-shrink: 0;
-  transition: opacity 0.15s, color 0.15s;
+  transition: opacity 0.15s;
 }
 
 .group-header-action svg {
@@ -1336,21 +1295,36 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   height: 14px;
 }
 
-.group-header:hover .group-header-action {
-  opacity: 0.8;
+/* Restore all — sage green */
+.group-header-action[data-action="restore-group-all"],
+.group-header-action[data-action="restore-archived-group"] {
+  color: var(--accent-sage);
+  opacity: 0.6;
 }
 
-.group-header-action:hover {
-  opacity: 1 !important;
-  color: var(--accent-sage);
+.group-header-action[data-action="restore-group-all"]:hover,
+.group-header-action[data-action="restore-archived-group"]:hover {
+  opacity: 1;
+}
+
+/* Archive (check-off) — amber */
+.group-header-action.group-check {
+  color: var(--accent-amber);
+  opacity: 0.6;
 }
 
 .group-header-action.group-check:hover {
-  color: var(--accent-amber);
+  opacity: 1;
+}
+
+/* Dismiss (delete) — rose/red */
+.group-header-action[data-action="dismiss-group"] {
+  color: var(--status-abandoned);
+  opacity: 0.5;
 }
 
 .group-header-action[data-action="dismiss-group"]:hover {
-  color: var(--status-abandoned);
+  opacity: 1;
 }
 
 /* Group body — list of items, collapsed when .collapsed set on group */


### PR DESCRIPTION
## Summary

- **Folder bar** — a horizontal chip strip above both columns showing "All" + a chip per folder. The active chip grows visually (larger padding, bold, dark fill). "New folder" chip creates + activates + opens the manage panel for immediate rename. "Manage" gear button toggles an inline panel listing all folders with rename/delete/reorder controls.
- **Focused folder view** — clicking a folder chip filters both columns to only that folder's content (flat list, no nested sections). Archive hidden during focus. Empty-state message shown when the folder is empty.
- **Folder system (new)** — full CRUD for folders with `chrome.storage.local`. Assign domain cards and saved items via a folder picker popup or drag-and-drop. Up/down reorder for both cards and saved items within folders. "changed X ago" timestamp on items.
- **Global search bar** — real-time filter across open-tab cards, saved items, and folder sections. Clear button auto-appears on input.
- **Render stability fixes** — `suppressAutoRefresh()` flag prevents the double re-render caused by `chrome.tabs.onRemoved` firing after intentional tab actions. Stable sort adds alphabetical tiebreaker for equal-count domain cards. FLIP animation capped at 250px so cards fade in instead of flying diagonally.
- **Folder icon sizes** — SVG icons in folder action buttons increased from 11–12 px to 14–16 px.

## ⚠️ Merge note

PR #3 (module split refactor) landed on `main` after this branch diverged. This PR is based on the previous monolithic `app.js`. Before merging, the changes here will need to be rebased onto the split-module structure (folder storage helpers → `storage.js`, render helpers → `render.js`, action handlers → `app.js` orchestrator). The `HANDOFF.txt` in this branch documents every change in full detail and can guide that integration.

## Test plan

- [ ] Create a folder from the "New folder" chip — bar appears, manage panel opens, rename input is focused
- [ ] Click a folder chip — both columns filter; "All" returns to unfiltered view
- [ ] Move a domain card and a saved item into a folder via the folder icon button
- [ ] Drag a domain card onto a folder header in the "All" view
- [ ] Rename a folder from the manage panel (pencil), confirm it updates everywhere
- [ ] Delete the active folder — filter resets to "All", items move to unfiled
- [ ] Reorder folders up/down in the manage panel
- [ ] Type in the search bar — cards/items filter live; folder headers hide when empty
- [ ] Close a single tab — no secondary re-render jank 400ms later
- [ ] Archive a domain group — no card grid shuffle after animation completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)