### PR TITLE
Add favorites and archive delete controls

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -25,6 +25,7 @@
 
 // All open tabs — populated by fetchOpenTabs()
 let openTabs = [];
+let favoriteNameWasEdited = false;
 
 /**
  * fetchOpenTabs()
@@ -283,6 +284,110 @@ async function dismissSavedTab(id) {
   }
 }
 
+/**
+ * deleteSavedTab(id)
+ *
+ * Permanently removes a saved tab from storage.
+ */
+async function deleteSavedTab(id) {
+  const { deferred = [] } = await chrome.storage.local.get('deferred');
+  await chrome.storage.local.set({
+    deferred: deferred.filter(t => t.id !== id),
+  });
+}
+
+
+/* ----------------------------------------------------------------
+   FAVORITES — chrome.storage.local
+   ---------------------------------------------------------------- */
+
+async function getFavoriteSites() {
+  const { favorites = [] } = await chrome.storage.local.get('favorites');
+  return favorites;
+}
+
+function normalizeFavoriteUrl(value) {
+  const raw = (value || '').trim();
+  if (!raw) return '';
+
+  const withProtocol = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(raw)
+    ? raw
+    : `https://${raw}`;
+  const parsed = new URL(withProtocol);
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error('Favorites must use http or https URLs');
+  }
+  return parsed.href;
+}
+
+function deriveFavoriteTitleFromUrl(value) {
+  try {
+    const parsed = new URL(normalizeFavoriteUrl(value));
+    return friendlyDomain(parsed.hostname) || parsed.hostname.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+}
+
+function autofillFavoriteNameFromUrl() {
+  const nameInput = document.getElementById('favoriteName');
+  const urlInput  = document.getElementById('favoriteUrl');
+  if (!nameInput || !urlInput) return;
+  if (favoriteNameWasEdited && nameInput.value.trim() !== '') return;
+
+  const suggestedTitle = deriveFavoriteTitleFromUrl(urlInput.value);
+  if (suggestedTitle) nameInput.value = suggestedTitle;
+}
+
+function setFavoriteFormOpen(open) {
+  const form = document.getElementById('favoriteForm');
+  const nameInput = document.getElementById('favoriteName');
+  const urlInput = document.getElementById('favoriteUrl');
+  const toggle = document.querySelector('[data-action="toggle-favorite-form"]');
+  if (!form) return;
+
+  form.style.display = open ? 'grid' : 'none';
+  if (toggle) toggle.classList.toggle('open', open);
+
+  if (open) {
+    favoriteNameWasEdited = false;
+    if (nameInput) nameInput.value = '';
+    if (urlInput) {
+      urlInput.value = '';
+      urlInput.focus();
+    }
+  }
+}
+
+async function saveFavoriteSite({ title, url }) {
+  const normalizedUrl = normalizeFavoriteUrl(url);
+  const parsed = new URL(normalizedUrl);
+  const displayTitle = (title || '').trim() || friendlyDomain(parsed.hostname) || parsed.hostname;
+  const { favorites = [] } = await chrome.storage.local.get('favorites');
+  const existing = favorites.find(site => site.url === normalizedUrl);
+
+  if (existing) {
+    existing.title = displayTitle;
+    existing.updatedAt = new Date().toISOString();
+  } else {
+    favorites.unshift({
+      id: Date.now().toString(),
+      title: displayTitle,
+      url: normalizedUrl,
+      createdAt: new Date().toISOString(),
+    });
+  }
+
+  await chrome.storage.local.set({ favorites });
+}
+
+async function deleteFavoriteSite(id) {
+  const { favorites = [] } = await chrome.storage.local.get('favorites');
+  await chrome.storage.local.set({
+    favorites: favorites.filter(site => site.id !== id),
+  });
+}
+
 
 /* ----------------------------------------------------------------
    UI HELPERS
@@ -489,6 +594,15 @@ function timeAgo(dateStr) {
   if (diffHours < 24) return diffHours + ' hr' + (diffHours !== 1 ? 's' : '') + ' ago';
   if (diffDays === 1) return 'yesterday';
   return diffDays + ' days ago';
+}
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 /**
@@ -700,6 +814,7 @@ const ICONS = {
   close:   `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>`,
   archive: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5m6 4.125l2.25 2.25m0 0l2.25 2.25M12 13.875l2.25-2.25M12 13.875l-2.25 2.25M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>`,
   focus:   `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>`,
+  trash:   `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673A2.25 2.25 0 0 1 15.916 21H8.084a2.25 2.25 0 0 1-2.244-1.327L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>`,
 };
 
 
@@ -898,6 +1013,57 @@ function renderDomainCard(group) {
 
 
 /* ----------------------------------------------------------------
+   FAVORITES — Render Top Section
+   ---------------------------------------------------------------- */
+
+async function renderFavoritesSection() {
+  const list    = document.getElementById('favoriteList');
+  const empty   = document.getElementById('favoriteEmpty');
+  if (!list) return;
+
+  try {
+    const favorites = await getFavoriteSites();
+
+    if (favorites.length === 0) {
+      list.innerHTML = '';
+      list.style.display = 'none';
+      if (empty) empty.style.display = 'none';
+      return;
+    }
+
+    list.innerHTML = favorites.map(renderFavoriteItem).join('');
+    list.style.display = 'grid';
+    if (empty) empty.style.display = 'none';
+  } catch (err) {
+    console.warn('[tab-out] Could not load favorites:', err);
+    list.innerHTML = '';
+  }
+}
+
+function renderFavoriteItem(site) {
+  let domain = '';
+  try { domain = new URL(site.url).hostname.replace(/^www\./, ''); } catch {}
+  const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+  const safeTitle = escapeHtml(site.title || site.url);
+  const safeUrl = escapeHtml(site.url || '');
+  const safeDomain = escapeHtml(domain);
+  const safeId = escapeHtml(site.id);
+
+  return `
+    <div class="favorite-item" data-favorite-id="${safeId}">
+      <button class="favorite-link" data-action="open-favorite" data-favorite-url="${safeUrl}" title="${safeTitle}">
+        ${faviconUrl ? `<img class="favorite-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+        <span class="favorite-title">${safeTitle}</span>
+        <span class="favorite-domain">${safeDomain}</span>
+      </button>
+      <button class="favorite-delete" data-action="delete-favorite" data-favorite-id="${safeId}" title="Delete favorite">
+        ${ICONS.trash}
+      </button>
+    </div>`;
+}
+
+
+/* ----------------------------------------------------------------
    SAVED FOR LATER — Render Checklist Column
    ---------------------------------------------------------------- */
 
@@ -994,12 +1160,18 @@ function renderDeferredItem(item) {
  */
 function renderArchiveItem(item) {
   const ago = item.completedAt ? timeAgo(item.completedAt) : timeAgo(item.savedAt);
+  const safeTitle = escapeHtml(item.title || item.url);
+  const safeUrl = escapeHtml(item.url || '');
+  const safeId = escapeHtml(item.id);
   return `
-    <div class="archive-item">
-      <a href="${item.url}" target="_blank" rel="noopener" class="archive-item-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
-        ${item.title || item.url}
+    <div class="archive-item" data-deferred-id="${safeId}">
+      <a href="${safeUrl}" target="_blank" rel="noopener" class="archive-item-title" title="${safeTitle}">
+        ${safeTitle}
       </a>
       <span class="archive-item-date">${ago}</span>
+      <button class="archive-delete" data-action="delete-archive-item" data-deferred-id="${safeId}" title="Delete archived tab">
+        ${ICONS.trash}
+      </button>
     </div>`;
 }
 
@@ -1025,6 +1197,9 @@ async function renderStaticDashboard() {
   const dateEl     = document.getElementById('dateDisplay');
   if (greetingEl) greetingEl.textContent = getGreeting();
   if (dateEl)     dateEl.textContent     = getDateDisplay();
+
+  // --- Favorites ---
+  await renderFavoritesSection();
 
   // --- Fetch tabs ---
   await fetchOpenTabs();
@@ -1188,6 +1363,40 @@ document.addEventListener('click', async (e) => {
 
   const action = actionEl.dataset.action;
 
+  // ---- Show/hide the compact favorite add form ----
+  if (action === 'toggle-favorite-form') {
+    const form = document.getElementById('favoriteForm');
+    const isOpen = form && form.style.display !== 'none';
+    setFavoriteFormOpen(!isOpen);
+    return;
+  }
+
+  // ---- Open a favorite website ----
+  if (action === 'open-favorite') {
+    e.preventDefault();
+    const url = actionEl.dataset.favoriteUrl;
+    if (url) await chrome.tabs.create({ url });
+    return;
+  }
+
+  // ---- Delete a favorite website ----
+  if (action === 'delete-favorite') {
+    e.stopPropagation();
+    const id = actionEl.dataset.favoriteId;
+    if (!id) return;
+
+    await deleteFavoriteSite(id);
+    const item = actionEl.closest('.favorite-item');
+    if (item) {
+      item.classList.add('removing');
+      setTimeout(() => renderFavoritesSection(), 180);
+    } else {
+      await renderFavoritesSection();
+    }
+    showToast('Favorite deleted');
+    return;
+  }
+
   // ---- Close duplicate Tab Out tabs ----
   if (action === 'close-tabout-dupes') {
     await closeTabOutDupes();
@@ -1340,6 +1549,23 @@ document.addEventListener('click', async (e) => {
     return;
   }
 
+  // ---- Delete an archived saved tab permanently ----
+  if (action === 'delete-archive-item') {
+    const id = actionEl.dataset.deferredId;
+    if (!id) return;
+
+    await deleteSavedTab(id);
+    const item = actionEl.closest('.archive-item');
+    if (item) {
+      item.classList.add('removing');
+      setTimeout(() => renderDeferredColumn(), 180);
+    } else {
+      await renderDeferredColumn();
+    }
+    showToast('Archived tab deleted');
+    return;
+  }
+
   // ---- Close all tabs in a domain group ----
   if (action === 'close-domain-tabs') {
     const domainId = actionEl.dataset.domainId;
@@ -1433,6 +1659,28 @@ document.addEventListener('click', async (e) => {
   }
 });
 
+document.addEventListener('submit', async (e) => {
+  if (e.target.id !== 'favoriteForm') return;
+  e.preventDefault();
+
+  const nameInput = document.getElementById('favoriteName');
+  const urlInput  = document.getElementById('favoriteUrl');
+  const title = nameInput ? nameInput.value : '';
+  const url   = urlInput ? urlInput.value : '';
+
+  try {
+    await saveFavoriteSite({ title, url });
+    if (nameInput) nameInput.value = '';
+    if (urlInput) urlInput.value = '';
+    favoriteNameWasEdited = false;
+    setFavoriteFormOpen(false);
+    await renderFavoritesSection();
+    showToast('Favorite saved');
+  } catch {
+    showToast('Enter a valid website URL');
+  }
+});
+
 // ---- Archive toggle — expand/collapse the archive section ----
 document.addEventListener('click', (e) => {
   const toggle = e.target.closest('#archiveToggle');
@@ -1447,6 +1695,16 @@ document.addEventListener('click', (e) => {
 
 // ---- Archive search — filter archived items as user types ----
 document.addEventListener('input', async (e) => {
+  if (e.target.id === 'favoriteName') {
+    favoriteNameWasEdited = true;
+    return;
+  }
+
+  if (e.target.id === 'favoriteUrl') {
+    autofillFavoriteNameFromUrl();
+    return;
+  }
+
   if (e.target.id !== 'archiveSearch') return;
 
   const q = e.target.value.trim().toLowerCase();

--- a/extension/index.html
+++ b/extension/index.html
@@ -47,6 +47,24 @@
   </div>
 
   <!-- ================================================================
+       FAVORITES — saved websites for quick access
+       ================================================================ -->
+  <section class="favorites-section" id="favoritesSection">
+    <div class="section-header favorites-header">
+      <h2>Favorites</h2>
+      <div class="section-line"></div>
+      <button class="favorite-toggle" data-action="toggle-favorite-form" title="Add favorite" aria-label="Add favorite">+</button>
+    </div>
+    <form class="favorite-form" id="favoriteForm" style="display:none">
+      <input type="text" class="favorite-input" id="favoriteName" placeholder="Name" autocomplete="off">
+      <input type="text" class="favorite-input favorite-url-input" id="favoriteUrl" placeholder="https://example.com" autocomplete="off" required>
+      <button class="favorite-add" type="submit">Add</button>
+    </form>
+    <div class="favorite-list" id="favoriteList"></div>
+    <div class="favorite-empty" id="favoriteEmpty" style="display:none"></div>
+  </section>
+
+  <!-- ================================================================
        MAIN CONTENT AREA — two-column layout
        Left: open tabs (domain/mission cards)
        Right: saved for later checklist

--- a/extension/style.css
+++ b/extension/style.css
@@ -184,6 +184,211 @@ header {
   font-weight: 600;
 }
 
+/* ---- Favorites ---- */
+.favorites-section {
+  margin-bottom: 32px;
+  padding: 8px 0 18px;
+  border-bottom: 1px solid var(--warm-gray);
+}
+
+.favorites-header {
+  margin-bottom: 12px;
+}
+
+.favorite-toggle {
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 22px;
+  font-weight: 500;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 0 3px;
+  transition: color 0.15s, background 0.15s, transform 0.15s;
+}
+
+.favorite-toggle:hover,
+.favorite-toggle.open {
+  color: var(--accent-sage);
+  background: rgba(90, 122, 98, 0.08);
+}
+
+.favorite-toggle.open {
+  transform: rotate(45deg);
+}
+
+.favorite-form {
+  display: grid;
+  grid-template-columns: minmax(120px, 180px) minmax(220px, 1fr) auto;
+  gap: 8px;
+  margin-bottom: 14px;
+  animation: fadeUp 0.2s ease both;
+}
+
+.favorite-input {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray);
+  border-radius: 6px;
+  padding: 9px 11px;
+  min-width: 0;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.favorite-input:focus {
+  border-color: rgba(90, 122, 98, 0.55);
+  box-shadow: 0 0 0 3px rgba(90, 122, 98, 0.08);
+}
+
+.favorite-input::placeholder {
+  color: var(--muted);
+}
+
+.favorite-add {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  color: white;
+  background: var(--accent-sage);
+  border: 1px solid var(--accent-sage);
+  border-radius: 6px;
+  padding: 0 18px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.15s, transform 0.15s;
+}
+
+.favorite-add:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.favorite-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 8px;
+}
+
+.favorite-item {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  border: 1px solid rgba(154, 145, 138, 0.18);
+  border-radius: 8px;
+  background: rgba(255, 253, 249, 0.72);
+  overflow: hidden;
+  transition: opacity 0.18s ease, transform 0.18s ease, border-color 0.15s;
+}
+
+.favorite-item:hover {
+  border-color: rgba(90, 122, 98, 0.32);
+}
+
+.favorite-link {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  column-gap: 8px;
+  row-gap: 1px;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  padding: 9px 10px;
+  border: none;
+  background: transparent;
+  color: var(--ink);
+  cursor: pointer;
+  text-align: left;
+}
+
+.favorite-favicon {
+  grid-row: 1 / 3;
+  width: 16px;
+  height: 16px;
+  border-radius: 2px;
+}
+
+.favorite-title {
+  font-size: 13px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.favorite-domain {
+  font-size: 11px;
+  color: var(--muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.favorite-delete,
+.archive-delete {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  border-radius: 4px;
+  opacity: 0.35;
+  transition: opacity 0.15s, color 0.15s, background 0.15s;
+  flex-shrink: 0;
+}
+
+.favorite-delete {
+  width: 30px;
+  height: 30px;
+  margin-right: 4px;
+}
+
+.favorite-delete svg,
+.archive-delete svg {
+  width: 14px;
+  height: 14px;
+}
+
+.favorite-delete:hover,
+.archive-delete:hover {
+  opacity: 1;
+  color: var(--status-abandoned);
+  background: rgba(179, 90, 90, 0.08);
+}
+
+.favorite-item.removing {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+.favorite-empty {
+  font-size: 12px;
+  color: var(--muted);
+  font-style: italic;
+  padding: 4px 0;
+}
+
+@media (max-width: 700px) {
+  .favorite-form {
+    grid-template-columns: 1fr;
+  }
+
+  .favorite-add {
+    min-height: 38px;
+  }
+}
+
 /* ---- Section Headers ---- */
 .section-header {
   display: flex;
@@ -1128,6 +1333,7 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   gap: 8px;
   padding: 6px 0;
   border-bottom: 1px solid rgba(154, 145, 138, 0.08);
+  transition: opacity 0.18s ease, transform 0.18s ease;
 }
 
 .archive-item:last-child {
@@ -1155,4 +1361,15 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   color: var(--muted);
   opacity: 0.6;
   flex-shrink: 0;
+}
+
+.archive-delete {
+  width: 24px;
+  height: 24px;
+  margin-left: -2px;
+}
+
+.archive-item.removing {
+  opacity: 0;
+  transform: translateX(12px);
 }

--- a/tests/static-ui.test.js
+++ b/tests/static-ui.test.js
@@ -1,0 +1,47 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+
+const root = path.resolve(__dirname, '..');
+const indexHtml = fs.readFileSync(path.join(root, 'extension/index.html'), 'utf8');
+const appJs = fs.readFileSync(path.join(root, 'extension/app.js'), 'utf8');
+const css = fs.readFileSync(path.join(root, 'extension/style.css'), 'utf8');
+
+test('renders a top favorites section before the dashboard columns', () => {
+  assert.match(indexHtml, /id="favoritesSection"/);
+  assert.match(indexHtml, /data-action="toggle-favorite-form"/);
+  assert.match(indexHtml, /id="favoriteForm"[^>]*style="display:none"/);
+  assert.match(indexHtml, /id="favoriteName"/);
+  assert.match(indexHtml, /id="favoriteUrl"/);
+  assert.ok(indexHtml.indexOf('id="favoritesSection"') < indexHtml.indexOf('id="dashboardColumns"'));
+});
+
+test('favorites are persisted, rendered, opened, and removed from chrome.storage.local', () => {
+  assert.match(appJs, /async function getFavoriteSites\(\)/);
+  assert.match(appJs, /async function saveFavoriteSite\(/);
+  assert.match(appJs, /async function deleteFavoriteSite\(/);
+  assert.match(appJs, /async function renderFavoritesSection\(\)/);
+  assert.match(appJs, /function deriveFavoriteTitleFromUrl\(/);
+  assert.match(appJs, /function autofillFavoriteNameFromUrl\(/);
+  assert.match(appJs, /favoriteNameWasEdited/);
+  assert.match(appJs, /action === 'toggle-favorite-form'/);
+  assert.match(appJs, /data-action="open-favorite"/);
+  assert.match(appJs, /data-action="delete-favorite"/);
+  assert.match(appJs, /chrome\.tabs\.create/);
+});
+
+test('archived saved tabs can be deleted from the archive list', () => {
+  assert.match(appJs, /async function deleteSavedTab\(/);
+  assert.match(appJs, /data-action="delete-archive-item"/);
+  assert.match(appJs, /action === 'delete-archive-item'/);
+});
+
+test('new favorite and archive controls have dedicated styling', () => {
+  assert.match(css, /\.favorites-section/);
+  assert.match(css, /\.favorite-toggle/);
+  assert.match(css, /\.favorite-toggle\s*\{[\s\S]*width:\s*28px;[\s\S]*height:\s*28px;[\s\S]*border-radius:\s*4px;[\s\S]*border:\s*none;/);
+  assert.match(css, /\.favorite-form/);
+  assert.match(css, /\.favorite-delete/);
+  assert.match(css, /\.archive-delete/);
+});


### PR DESCRIPTION
## Summary
- Add a compact Favorites section for saved websites on the new tab dashboard
- Let users add favorites from a collapsed plus button, with URL-based name autofill that remains editable
- Add delete controls for archived saved tabs
- Add lightweight static UI tests for the new controls

## Validation
- node --check extension/app.js
- node --test tests/static-ui.test.js
