### PR TITLE
Firefox support via shared manifest

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -34,9 +34,10 @@ let openTabs = [];
  */
 async function fetchOpenTabs() {
   try {
-    const extensionId = chrome.runtime.id;
-    // The new URL for this page is now index.html (not newtab.html)
-    const newtabUrl = `chrome-extension://${extensionId}/index.html`;
+    // runtime.getURL() returns the right scheme per browser:
+    //   chrome-extension://<id>/index.html  in Chrome
+    //   moz-extension://<id>/index.html     in Firefox
+    const newtabUrl = chrome.runtime.getURL('index.html');
 
     const tabs = await chrome.tabs.query({});
     openTabs = tabs.map(t => ({
@@ -46,7 +47,12 @@ async function fetchOpenTabs() {
       windowId: t.windowId,
       active:   t.active,
       // Flag Tab Out's own pages so we can detect duplicate new tabs
-      isTabOut: t.url === newtabUrl || t.url === 'chrome://newtab/',
+      // (Chrome's blank new tab is chrome://newtab/; Firefox's is about:newtab or about:home)
+      isTabOut:
+        t.url === newtabUrl ||
+        t.url === 'chrome://newtab/' ||
+        t.url === 'about:newtab' ||
+        t.url === 'about:home',
     }));
   } catch {
     // chrome.tabs API unavailable (shouldn't happen in an extension page)
@@ -175,13 +181,16 @@ async function closeDuplicateTabs(urls, keepOne = true) {
  * Closes all duplicate Tab Out new-tab pages except the current one.
  */
 async function closeTabOutDupes() {
-  const extensionId = chrome.runtime.id;
-  const newtabUrl = `chrome-extension://${extensionId}/index.html`;
+  // Cross-browser: chrome-extension:// in Chrome, moz-extension:// in Firefox
+  const newtabUrl = chrome.runtime.getURL('index.html');
 
   const allTabs = await chrome.tabs.query({});
   const currentWindow = await chrome.windows.getCurrent();
   const tabOutTabs = allTabs.filter(t =>
-    t.url === newtabUrl || t.url === 'chrome://newtab/'
+    t.url === newtabUrl ||
+    t.url === 'chrome://newtab/' ||
+    t.url === 'about:newtab' ||
+    t.url === 'about:home'
   );
 
   if (tabOutTabs.length <= 1) return;
@@ -725,6 +734,8 @@ function getRealTabs() {
     return (
       !url.startsWith('chrome://') &&
       !url.startsWith('chrome-extension://') &&
+      !url.startsWith('moz-extension://') &&
+      !url.startsWith('resource://') &&
       !url.startsWith('about:') &&
       !url.startsWith('edge://') &&
       !url.startsWith('brave://')

--- a/extension/background.js
+++ b/extension/background.js
@@ -26,11 +26,15 @@ async function updateBadge() {
     const tabs = await chrome.tabs.query({});
 
     // Only count actual web pages — skip browser internals and extension pages
+    // Includes Firefox schemes (moz-extension://, resource://, about:*) so the
+    // badge stays accurate when running as a Firefox WebExtension.
     const count = tabs.filter(t => {
       const url = t.url || '';
       return (
         !url.startsWith('chrome://') &&
         !url.startsWith('chrome-extension://') &&
+        !url.startsWith('moz-extension://') &&
+        !url.startsWith('resource://') &&
         !url.startsWith('about:') &&
         !url.startsWith('edge://') &&
         !url.startsWith('brave://')

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,7 +5,10 @@
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
   "permissions": ["tabs", "activeTab", "storage"],
   "chrome_url_overrides": { "newtab": "index.html" },
-  "background": { "service_worker": "background.js" },
+  "background": {
+    "service_worker": "background.js",
+    "scripts": ["background.js"]
+  },
   "action": {
     "default_title": "Tab Out",
     "default_icon": {
@@ -17,5 +20,11 @@
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "tab-out@zarazhangrui.github.io",
+      "strict_min_version": "121.0"
+    }
   }
 }


### PR DESCRIPTION
Closes #11 

Adds Firefox support without forking the codebase. The extension already
uses the WebExtension API surface (`chrome.tabs`, `chrome.storage`,
`chrome.action`, `chrome_url_overrides`) and Firefox aliases `chrome.*`
to `browser.*`, so the only real divergences are URL schemes and the
manifest. Three small changes are enough.

## Changes (32 lines, 3 files)

**`manifest.json`** — make the same manifest load in both browsers:
- Add `background.scripts: ["background.js"]` next to `service_worker`. Chrome MV3 uses `service_worker`; Firefox MV3 uses `scripts` as an event-page entry. Both keys coexist.
- Add `browser_specific_settings.gecko` with extension `id` and `strict_min_version: "121.0"` (the Firefox version that ships MV3 + the APIs used here).

**`app.js`** — three URL-handling sites:
- Replace hardcoded `` `chrome-extension://${id}/index.html` `` with `chrome.runtime.getURL('index.html')`. That returns `chrome-extension://...` in Chrome and `moz-extension://...` in Firefox, so Tab Out's own pages are detected correctly in both.
- When matching the empty new-tab page, accept `chrome://newtab/` (Chrome), `about:newtab` (Firefox), and `about:home` (Firefox alternate).
- In `getRealTabs()`, also exclude `moz-extension://` and `resource://` so Firefox internals don't show up in the grid.

**`background.js`** — apply the same `moz-extension://` and `resource://` filters in the badge counter, so the badge doesn't inflate by 1 on every Tab Out tab when running in Firefox.