### PR TITLE
feat: dark theme with system / light / dark modes

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -17,6 +17,50 @@
 
 
 /* ----------------------------------------------------------------
+   THEME MODE
+   Mode = "system" | "light" | "dark"; default = system (follows OS).
+   theme-init.js applies the initial mode before <body> paints;
+   this file owns runtime updates, OS-change tracking, and cross-tab sync.
+   ---------------------------------------------------------------- */
+
+function applyThemeMode(mode) {
+  const root = document.documentElement;
+  const prefersDark = window.matchMedia &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const isDark = mode === 'dark' || (mode === 'system' && prefersDark);
+  if (isDark) root.setAttribute('data-theme', 'dark');
+  else        root.removeAttribute('data-theme');
+  root.setAttribute('data-mode', mode);
+}
+
+// Re-apply when the OS toggles light/dark — but only while in "system" mode.
+if (window.matchMedia) {
+  const mq = window.matchMedia('(prefers-color-scheme: dark)');
+  const onChange = () => {
+    const mode = document.documentElement.getAttribute('data-mode') || 'system';
+    if (mode === 'system') applyThemeMode('system');
+  };
+  if (mq.addEventListener) mq.addEventListener('change', onChange);
+  else if (mq.addListener) mq.addListener(onChange); // older Safari fallback
+}
+
+// Sync across other open new-tab pages: when one tab toggles the theme,
+// chrome.storage.onChanged fires here too.
+try {
+  if (chrome && chrome.storage && chrome.storage.onChanged) {
+    chrome.storage.onChanged.addListener((changes, area) => {
+      if (area !== 'local' || !changes.theme) return;
+      const next = changes.theme.newValue;
+      if (next !== 'light' && next !== 'dark' && next !== 'system') return;
+      if (next === document.documentElement.getAttribute('data-mode')) return;
+      applyThemeMode(next);
+      try { localStorage.setItem('tabout-theme', next); } catch (err) {}
+    });
+  }
+} catch (err) {}
+
+
+/* ----------------------------------------------------------------
    CHROME TABS — Direct API Access
 
    Since this page IS the extension's new tab page, it has full
@@ -1187,6 +1231,20 @@ document.addEventListener('click', async (e) => {
   if (!actionEl) return;
 
   const action = actionEl.dataset.action;
+
+  // ---- Cycle theme mode: system → light → dark → system ----
+  // Persisted to chrome.storage.local (shared across all new-tab pages),
+  // mirrored to localStorage so theme-init.js can apply it synchronously
+  // before paint and avoid a flash of light content.
+  if (action === 'toggle-theme') {
+    const root = document.documentElement;
+    const cur = root.getAttribute('data-mode') || 'system';
+    const next = cur === 'system' ? 'light' : cur === 'light' ? 'dark' : 'system';
+    applyThemeMode(next);
+    try { localStorage.setItem('tabout-theme', next); } catch (err) {}
+    try { await chrome.storage.local.set({ theme: next }); } catch (err) {}
+    return;
+  }
 
   // ---- Close duplicate Tab Out tabs ----
   if (action === 'close-tabout-dupes') {

--- a/extension/index.html
+++ b/extension/index.html
@@ -10,6 +10,10 @@
   <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300;0,6..72,400;0,6..72,500;1,6..72,300;1,6..72,400&family=DM+Sans:wght@300;400;500;600&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="style.css">
+
+  <!-- Apply saved theme mode before <body> paints. MUST be an external
+       file: MV3 extension pages block inline scripts via default CSP. -->
+  <script src="theme-init.js"></script>
 </head>
 <body>
 <div class="container">
@@ -25,6 +29,22 @@
       <h1 id="greeting"></h1>
       <!-- "Friday, April 4, 2026" — written by getDateDisplay() in app.js -->
       <div class="date" id="dateDisplay"></div>
+    </div>
+    <div class="header-right">
+      <button class="theme-toggle" id="themeToggle" data-action="toggle-theme" aria-label="Cycle theme: system, light, dark" title="Cycle theme (system / light / dark)">
+        <!-- Monitor icon — shown when mode = system -->
+        <svg class="theme-icon theme-icon-system" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25" />
+        </svg>
+        <!-- Sun icon — shown when mode = light -->
+        <svg class="theme-icon theme-icon-light" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" />
+        </svg>
+        <!-- Moon icon — shown when mode = dark -->
+        <svg class="theme-icon theme-icon-dark" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.6" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z" />
+        </svg>
+      </button>
     </div>
   </header>
 

--- a/extension/style.css
+++ b/extension/style.css
@@ -18,6 +18,31 @@
   --status-abandoned: #b35a5a;
   --card-bg: #fffdf9;
   --shadow: rgba(26, 22, 19, 0.06);
+  --noise-opacity: 0.03;
+}
+
+/* ---- Dark theme — activated by [data-theme="dark"] on <html> ---- */
+:root[data-theme="dark"] {
+  --ink: #e8e2da;
+  --paper: #0f0d0b;
+  --warm-gray: #2a2520;
+  --muted: #8a817a;
+  --accent-amber: #d8895a;
+  --accent-sage: #7aa085;
+  --accent-slate: #7a8a9a;
+  --accent-rose: #c87a7a;
+  --status-active: #5a9a6a;
+  --status-cooling: #d8a94a;
+  --status-abandoned: #c87a7a;
+  --card-bg: #1a1714;
+  --shadow: rgba(0, 0, 0, 0.4);
+  --noise-opacity: 0.05;
+}
+
+/* Adjust the paper-noise overlay so it stays subtle on dark mode */
+:root[data-theme="dark"] body::before {
+  filter: invert(1);
+  opacity: 0.6;
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -80,6 +105,48 @@ header {
   letter-spacing: 0.5px;
   text-transform: uppercase;
 }
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* ---- Theme toggle button ---- */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid var(--warm-gray);
+  background: var(--card-bg);
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 0.2s, border-color 0.2s, background 0.2s, transform 0.2s;
+}
+
+.theme-toggle:hover {
+  color: var(--ink);
+  border-color: var(--ink);
+  transform: translateY(-1px);
+}
+
+.theme-toggle svg {
+  width: 18px;
+  height: 18px;
+}
+
+/* Show only the icon matching the current theme mode (system/light/dark).
+   Default = system before JS sets data-mode. */
+.theme-icon { display: none; }
+.theme-icon-system { display: block; }
+:root[data-mode="light"] .theme-icon-system { display: none; }
+:root[data-mode="light"] .theme-icon-light  { display: block; }
+:root[data-mode="dark"]  .theme-icon-system { display: none; }
+:root[data-mode="dark"]  .theme-icon-dark   { display: block; }
 
 /* ---- Tab cleanup banner ---- */
 .tab-cleanup-banner {

--- a/extension/theme-init.js
+++ b/extension/theme-init.js
@@ -1,0 +1,45 @@
+/* ================================================================
+   Theme bootstrap — runs synchronously before <body> is parsed so
+   the page paints with the correct theme attributes from the start.
+
+   Must live in an external file: Manifest V3 extension pages forbid
+   inline <script> blocks via the default CSP, so an inline tag is
+   silently dropped and the page would render in default light mode.
+
+   Mode = "system" | "light" | "dark"; default = system (follows OS).
+   ================================================================ */
+(function () {
+  function apply(mode) {
+    var prefersDark = window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var isDark = mode === 'dark' || (mode === 'system' && prefersDark);
+    if (isDark) document.documentElement.setAttribute('data-theme', 'dark');
+    else        document.documentElement.removeAttribute('data-theme');
+    document.documentElement.setAttribute('data-mode', mode);
+  }
+
+  // Sync read from localStorage mirror — instant, no flash.
+  var mode = 'system';
+  try {
+    var v = localStorage.getItem('tabout-theme');
+    if (v === 'light' || v === 'dark' || v === 'system') mode = v;
+  } catch (e) {}
+  apply(mode);
+
+  // Async reconcile with chrome.storage.local (canonical, shared store).
+  // If the mirror was missing or stale, this corrects it; if the canonical
+  // store has nothing yet, push the current mode so future tabs find it.
+  try {
+    if (typeof chrome !== 'undefined' && chrome.storage && chrome.storage.local) {
+      chrome.storage.local.get('theme', function (res) {
+        var saved = res && res.theme;
+        if (saved !== 'light' && saved !== 'dark' && saved !== 'system') {
+          try { chrome.storage.local.set({ theme: mode }); } catch (e) {}
+          return;
+        }
+        if (saved !== mode) apply(saved);
+        try { localStorage.setItem('tabout-theme', saved); } catch (e) {}
+      });
+    }
+  } catch (e) {}
+})();


### PR DESCRIPTION
## Summary
- Adds a theme toggle in the header that cycles **system → light → dark**, defaulting to system so it follows the OS appearance.
- Re-applies automatically on OS theme change via `prefers-color-scheme`; cross-tab sync via `chrome.storage.onChanged`.
- Persists to `chrome.storage.local` (canonical, shared across new-tab pages) with a `localStorage` mirror so `theme-init.js` applies the mode synchronously before `<body>` paints — no flash of light content.

## Implementation notes
- All theme variables (`--ink`, `--paper`, `--card-bg`, accents, shadow, etc.) get a `:root[data-theme="dark"]` override; the existing paper-noise overlay is inverted in dark mode.
- A new `extension/theme-init.js` is loaded synchronously in `<head>`. It must be an external file because MV3's default CSP blocks inline `<script>` blocks on extension pages — an inline pre-paint hook silently no-ops.
- The toggle button in the header shows a single icon for the current mode (monitor / sun / moon). Click cycles to the next.

## Test plan
- [x] Toggle cycles system → light → dark in the header.
- [x] Reload the extension, open a fresh new tab — selected mode persists.
- [x] In `system` mode, change macOS / Windows appearance — page repaints to match without reload.
- [x] Open two new tabs, toggle in one — the other syncs via `chrome.storage.onChanged`.
- [x] No flash of light content on new-tab open when dark is selected.