### PR TITLE
🐛 fix: support Tab Suspender by extracting original URLs from suspended tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ docs/superpowers/
 
 # Personal config (landing page patterns, etc.) — never push to GitHub
 extension/config.local.js
+
+.trae/
+.omc/

--- a/extension/ai-api.js
+++ b/extension/ai-api.js
@@ -83,11 +83,15 @@ async function fetchGroupingSuggestions(tabs, settings, externalSignal, existing
   }
 }
 
-async function fetchTabSearch(query, tabs, settings, externalSignal) {
+async function fetchTabSearch(query, tabs, historyItems, settings, externalSignal) {
   const startTime = Date.now();
+  const allItems = [];
+  tabs.forEach((t, i) => allItems.push(`${allItems.length + 1}. [OPEN] ${t.title} - ${t.url}`));
+  historyItems.forEach((h, i) => allItems.push(`${allItems.length + 1}. [HISTORY] ${h.title} - ${h.url}`));
+
   const messages = [
-    { role: 'system', content: 'You find browser tabs matching a user description. Return ONLY valid JSON, no markdown.' },
-    { role: 'user', content: `Tabs:\n${tabs.map((t, i) => `${i + 1}. ${t.title} - ${t.url}`).join('\n')}\n\nFind tabs matching: "${query}"\nReturn: {"matches": [1, 5, 12]}  (tab indices that match)` }
+    { role: 'system', content: 'You find browser tabs/pages matching a user description. Rank by relevance. Return ONLY valid JSON, no markdown.' },
+    { role: 'user', content: `Items:\n${allItems.join('\n')}\n\nFind items matching: "${query}"\nReturn: {"matches": [3, 1, 7]}  (indices ranked by relevance, best first)` }
   ];
 
   try {
@@ -112,20 +116,23 @@ async function fetchTabSearch(query, tabs, settings, externalSignal) {
 
     if (!response.ok) {
       window.__aiDebug.push({ timestamp: Date.now(), type: 'search', query, prompt: messages, response: `HTTP ${response.status}`, parsed: null, duration: Date.now() - startTime });
-      return [];
+      return { openMatches: [], historyMatches: [] };
     }
     const data = await response.json();
     const content = data.choices[0].message.content;
     const parsed = JSON.parse(content.replace(/```json\s*|```\s*/g, '').trim());
     if (!Array.isArray(parsed.matches)) {
       window.__aiDebug.push({ timestamp: Date.now(), type: 'search', query, prompt: messages, response: content, parsed: null, duration: Date.now() - startTime });
-      return [];
+      return { openMatches: [], historyMatches: [] };
     }
-    const result = parsed.matches.filter(i => typeof i === 'number' && i >= 1 && i <= tabs.length);
-    window.__aiDebug.push({ timestamp: Date.now(), type: 'search', query, prompt: messages, response: content, parsed: result, duration: Date.now() - startTime });
-    return result;
+    const valid = parsed.matches.filter(i => typeof i === 'number' && i >= 1 && i <= allItems.length);
+    const openCount = tabs.length;
+    const openMatches = valid.filter(i => i <= openCount);
+    const historyMatches = valid.filter(i => i > openCount).map(i => i - openCount);
+    window.__aiDebug.push({ timestamp: Date.now(), type: 'search', query, prompt: messages, response: content, parsed: { openMatches, historyMatches }, duration: Date.now() - startTime });
+    return { openMatches, historyMatches };
   } catch (e) {
     window.__aiDebug.push({ timestamp: Date.now(), type: 'search', query, prompt: messages, response: e.message, parsed: null, duration: Date.now() - startTime });
-    return [];
+    return { openMatches: [], historyMatches: [] };
   }
 }

--- a/extension/ai-api.js
+++ b/extension/ai-api.js
@@ -1,0 +1,131 @@
+window.__aiDebug = [];
+
+async function fetchGroupingSuggestions(tabs, settings, externalSignal, existingGroups) {
+  const startTime = Date.now();
+  const tabList = tabs.map((t, i) => `${i + 1}. ${t.title} - ${t.url}${t.description ? ' | ' + t.description : ''}`).join('\n');
+  let existingInfo = '';
+  if (existingGroups && existingGroups.length > 0) {
+    existingInfo = '\n\nAlready grouped (DO NOT suggest these again):\n' + existingGroups.map(g => `- "${g.groupLabel}": ${g.rule.hostnames.join(', ')}`).join('\n');
+  }
+  const messages = [
+    {
+      role: 'system',
+      content: 'You are a browser tab organizer. Analyze the user\'s open tabs and find groups of 2+ tabs that share a common research topic or task. Also suggest better display names for domain groups that have 2+ tabs. Also identify tabs that look stale or unnecessary. Return ONLY valid JSON, no markdown.'
+    },
+    {
+      role: 'user',
+      content: `Here are my open tabs:\n${tabList}${existingInfo}\n\nReturn JSON with:\n1. "suggestions": [{"label": "短标签", "tab_indices": [1,2,3], "reasoning": "为什么这些标签相关"}] — 1-3 groups of 2+ related tabs\n2. "renames": [{"original_domain": "hostname", "suggested_name": "短名称"}] — friendlier names for domain groups\n3. "close_suggestions": [{"tab_indices": [4,7], "reasoning": "为什么这些标签可以关闭"}] — tabs that look like one-time lookups or completed tasks`
+    }
+  ];
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    if (externalSignal) externalSignal.addEventListener('abort', () => controller.abort());
+
+    let response;
+    try {
+      response = await fetch(`${settings.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${settings.apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        signal: controller.signal,
+        body: JSON.stringify({ model: settings.model, messages })
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+      window.__aiDebug.push({ timestamp: Date.now(), type: 'grouping', prompt: messages, response: `HTTP ${response.status}`, parsed: null, duration: Date.now() - startTime });
+      return { suggestions: [], renames: [], closeSuggestions: [] };
+    }
+
+    const data = await response.json();
+    const content = data.choices[0].message.content;
+    const parsed = JSON.parse(content.replace(/```json\s*|```\s*/g, '').trim());
+
+    if (!Array.isArray(parsed.suggestions)) {
+      window.__aiDebug.push({ timestamp: Date.now(), type: 'grouping', prompt: messages, response: content, parsed: null, duration: Date.now() - startTime });
+      return { suggestions: [], renames: [], closeSuggestions: [] };
+    }
+
+    const results = [];
+    for (const item of parsed.suggestions) {
+      if (typeof item.label !== 'string' || !Array.isArray(item.tab_indices) || !item.tab_indices.every(i => typeof i === 'number' && i >= 1 && i <= tabs.length) || typeof item.reasoning !== 'string') continue;
+      results.push({ groupLabel: item.label, tabIndices: item.tab_indices, reasoning: item.reasoning });
+    }
+
+    const validatedRenames = [];
+    if (Array.isArray(parsed.renames)) {
+      for (const r of parsed.renames) {
+        if (typeof r.original_domain === 'string' && typeof r.suggested_name === 'string') validatedRenames.push(r);
+      }
+    }
+
+    const validatedClose = [];
+    if (Array.isArray(parsed.close_suggestions)) {
+      for (const c of parsed.close_suggestions) {
+        if (Array.isArray(c.tab_indices) && c.tab_indices.every(i => typeof i === 'number' && i >= 1 && i <= tabs.length) && typeof c.reasoning === 'string') {
+          validatedClose.push({ tabIndices: c.tab_indices, reasoning: c.reasoning });
+        }
+      }
+    }
+
+    const result = { suggestions: results, renames: validatedRenames, closeSuggestions: validatedClose };
+    window.__aiDebug.push({ timestamp: Date.now(), type: 'grouping', prompt: messages, response: content, parsed: result, duration: Date.now() - startTime });
+    return result;
+  } catch (e) {
+    window.__aiDebug.push({ timestamp: Date.now(), type: 'grouping', prompt: messages, response: e.message, parsed: null, duration: Date.now() - startTime });
+    return { suggestions: [], renames: [], closeSuggestions: [] };
+  }
+}
+
+async function fetchTabSearch(query, tabs, settings, externalSignal) {
+  const startTime = Date.now();
+  const messages = [
+    { role: 'system', content: 'You find browser tabs matching a user description. Return ONLY valid JSON, no markdown.' },
+    { role: 'user', content: `Tabs:\n${tabs.map((t, i) => `${i + 1}. ${t.title} - ${t.url}`).join('\n')}\n\nFind tabs matching: "${query}"\nReturn: {"matches": [1, 5, 12]}  (tab indices that match)` }
+  ];
+
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    if (externalSignal) externalSignal.addEventListener('abort', () => controller.abort());
+
+    let response;
+    try {
+      response = await fetch(`${settings.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${settings.apiKey}`,
+          'Content-Type': 'application/json'
+        },
+        signal: controller.signal,
+        body: JSON.stringify({ model: settings.model, messages })
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (!response.ok) {
+      window.__aiDebug.push({ timestamp: Date.now(), type: 'search', query, prompt: messages, response: `HTTP ${response.status}`, parsed: null, duration: Date.now() - startTime });
+      return [];
+    }
+    const data = await response.json();
+    const content = data.choices[0].message.content;
+    const parsed = JSON.parse(content.replace(/```json\s*|```\s*/g, '').trim());
+    if (!Array.isArray(parsed.matches)) {
+      window.__aiDebug.push({ timestamp: Date.now(), type: 'search', query, prompt: messages, response: content, parsed: null, duration: Date.now() - startTime });
+      return [];
+    }
+    const result = parsed.matches.filter(i => typeof i === 'number' && i >= 1 && i <= tabs.length);
+    window.__aiDebug.push({ timestamp: Date.now(), type: 'search', query, prompt: messages, response: content, parsed: result, duration: Date.now() - startTime });
+    return result;
+  } catch (e) {
+    window.__aiDebug.push({ timestamp: Date.now(), type: 'search', query, prompt: messages, response: e.message, parsed: null, duration: Date.now() - startTime });
+    return [];
+  }
+}

--- a/extension/app.js
+++ b/extension/app.js
@@ -26,30 +26,45 @@
 // All open tabs — populated by fetchOpenTabs()
 let openTabs = [];
 
-/**
- * fetchOpenTabs()
- *
- * Reads all currently open browser tabs directly from Chrome.
- * Sets the extensionId flag so we can identify Tab Out's own pages.
- */
+function extractSuspendedUrl(url) {
+  if (!url || !url.startsWith('chrome-extension://')) return null;
+  try {
+    const parsed = new URL(url);
+    for (const key of ['url', 'uri']) {
+      const val = parsed.searchParams.get(key);
+      if (val && (val.startsWith('http://') || val.startsWith('https://') || val.startsWith('file://'))) return val;
+    }
+    const hash = parsed.hash.slice(1);
+    if (hash) {
+      const params = new URLSearchParams(hash);
+      for (const key of ['uri', 'url']) {
+        const val = params.get(key);
+        if (val && (val.startsWith('http://') || val.startsWith('https://') || val.startsWith('file://'))) return val;
+      }
+    }
+  } catch {}
+  return null;
+}
+
 async function fetchOpenTabs() {
   try {
     const extensionId = chrome.runtime.id;
-    // The new URL for this page is now index.html (not newtab.html)
     const newtabUrl = `chrome-extension://${extensionId}/index.html`;
 
     const tabs = await chrome.tabs.query({});
-    openTabs = tabs.map(t => ({
-      id:       t.id,
-      url:      t.url,
-      title:    t.title,
-      windowId: t.windowId,
-      active:   t.active,
-      // Flag Tab Out's own pages so we can detect duplicate new tabs
-      isTabOut: t.url === newtabUrl || t.url === 'chrome://newtab/',
-    }));
+    openTabs = tabs.map(t => {
+      const suspendedOriginal = extractSuspendedUrl(t.url);
+      return {
+        id:        t.id,
+        url:       suspendedOriginal || t.url,
+        title:     t.title,
+        windowId:  t.windowId,
+        active:    t.active,
+        suspended: !!suspendedOriginal,
+        isTabOut:  t.url === newtabUrl || t.url === 'chrome://newtab/',
+      };
+    });
   } catch {
-    // chrome.tabs API unavailable (shouldn't happen in an extension page)
     openTabs = [];
   }
 }
@@ -81,7 +96,7 @@ async function closeTabsByUrls(urls) {
   const allTabs = await chrome.tabs.query({});
   const toClose = allTabs
     .filter(tab => {
-      const tabUrl = tab.url || '';
+      const tabUrl = extractSuspendedUrl(tab.url) || tab.url || '';
       if (tabUrl.startsWith('file://') && exactUrls.has(tabUrl)) return true;
       try {
         const tabHostname = new URL(tabUrl).hostname;
@@ -104,7 +119,7 @@ async function closeTabsExact(urls) {
   if (!urls || urls.length === 0) return;
   const urlSet = new Set(urls);
   const allTabs = await chrome.tabs.query({});
-  const toClose = allTabs.filter(t => urlSet.has(t.url)).map(t => t.id);
+  const toClose = allTabs.filter(t => urlSet.has(t.url) || urlSet.has(extractSuspendedUrl(t.url))).map(t => t.id);
   if (toClose.length > 0) await chrome.tabs.remove(toClose);
   await fetchOpenTabs();
 }
@@ -120,15 +135,16 @@ async function focusTab(url) {
   const allTabs = await chrome.tabs.query({});
   const currentWindow = await chrome.windows.getCurrent();
 
-  // Try exact URL match first
-  let matches = allTabs.filter(t => t.url === url);
+  // Try exact URL match (including suspended tab original URL)
+  let matches = allTabs.filter(t => t.url === url || extractSuspendedUrl(t.url) === url);
 
   // Fall back to hostname match
   if (matches.length === 0) {
     try {
       const targetHost = new URL(url).hostname;
       matches = allTabs.filter(t => {
-        try { return new URL(t.url).hostname === targetHost; }
+        const effective = extractSuspendedUrl(t.url) || t.url;
+        try { return new URL(effective).hostname === targetHost; }
         catch { return false; }
       });
     } catch {}
@@ -154,7 +170,7 @@ async function closeDuplicateTabs(urls, keepOne = true) {
   const toClose = [];
 
   for (const url of urls) {
-    const matching = allTabs.filter(t => t.url === url);
+    const matching = allTabs.filter(t => t.url === url || extractSuspendedUrl(t.url) === url);
     if (keepOne) {
       const keep = matching.find(t => t.active) || matching[0];
       for (const tab of matching) {
@@ -511,6 +527,106 @@ function getDateDisplay() {
     month:   'long',
     day:     'numeric',
   });
+}
+
+
+/* ----------------------------------------------------------------
+   AI SUGGESTION BANNERS
+   ---------------------------------------------------------------- */
+
+let pendingSuggestions = [];
+
+/**
+ * renderSuggestionBanners(suggestions)
+ *
+ * Takes an array of AI grouping suggestions and renders one banner at a time.
+ * Each suggestion: { groupLabel, tabIndices, reasoning }
+ */
+function renderSuggestionBanners(suggestions) {
+  pendingSuggestions = suggestions || [];
+  renderNextSuggestionBanner();
+}
+
+function renderNextSuggestionBanner() {
+  const container = document.getElementById('openTabsMissions');
+  if (!container) return;
+
+  // Remove any existing banner
+  const existing = container.querySelector('.ai-suggestion-banner');
+  if (existing) existing.remove();
+
+  if (pendingSuggestions.length === 0) return;
+
+  const suggestion = pendingSuggestions[0];
+  const tabCount = suggestion.tabIndices ? suggestion.tabIndices.length : 0;
+
+  function esc(s) { return (s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+  const bannerHtml = `<div class="ai-suggestion-banner" data-suggestion-index="0">
+  <span class="suggestion-icon">✨</span>
+  <div class="suggestion-content">
+    <div class="suggestion-label">合并为一组？[${esc(suggestion.groupLabel)}] — ${tabCount} 个标签</div>
+    <div class="suggestion-meta">${esc(suggestion.reasoning)}</div>
+  </div>
+  <div class="suggestion-actions">
+    <button class="btn-accept" data-action="accept-suggestion">接受</button>
+    <button class="btn-dismiss" data-action="dismiss-suggestion">忽略</button>
+  </div>
+</div>`;
+
+  const firstCard = container.querySelector('.mission-card');
+  if (firstCard) {
+    firstCard.insertAdjacentHTML('beforebegin', bannerHtml);
+  } else {
+    container.insertAdjacentHTML('afterbegin', bannerHtml);
+  }
+}
+
+
+/* ----------------------------------------------------------------
+   AI CLOSE SUGGESTION BANNERS
+   ---------------------------------------------------------------- */
+
+let pendingCloseSuggestions = [];
+
+function renderCloseSuggestions(suggestions) {
+  pendingCloseSuggestions = suggestions || [];
+  renderNextCloseBanner();
+}
+
+function renderNextCloseBanner() {
+  const container = document.getElementById('openTabsMissions');
+  if (!container) return;
+
+  const existing = container.querySelector('.ai-close-banner');
+  if (existing) existing.remove();
+
+  if (pendingCloseSuggestions.length === 0) return;
+  if (pendingSuggestions.length > 0) return;
+
+  const suggestion = pendingCloseSuggestions[0];
+  const tabCount = suggestion.tabIndices ? suggestion.tabIndices.length : 0;
+
+  function esc(s) { return (s || '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+
+  const bannerHtml = `<div class="ai-close-banner">
+  <span class="suggestion-icon">🧹</span>
+  <div class="suggestion-content">
+    <div class="suggestion-label">可以关掉？— ${tabCount} 个标签</div>
+    <div class="suggestion-meta">${esc(suggestion.reasoning)}</div>
+  </div>
+  <div class="suggestion-actions">
+    <button class="btn-close-accept" data-action="accept-close-suggestion">关闭</button>
+    <button class="btn-dismiss" data-action="dismiss-close-suggestion">保留</button>
+  </div>
+</div>`;
+
+  const firstCard = container.querySelector('.mission-card');
+  if (firstCard) {
+    firstCard.insertAdjacentHTML('beforebegin', bannerHtml);
+  } else {
+    container.insertAdjacentHTML('afterbegin', bannerHtml);
+  }
 }
 
 
@@ -1070,6 +1186,15 @@ async function renderStaticDashboard() {
   // Custom group rules from config.local.js (if any)
   const customGroups = typeof LOCAL_CUSTOM_GROUPS !== 'undefined' ? LOCAL_CUSTOM_GROUPS : [];
 
+  // AI-learned group rules from chrome.storage.local
+  let learnedGroups = [];
+  try {
+    const stored = await new Promise(resolve =>
+      chrome.storage.local.get('ai_learned_groups', r => resolve(r.ai_learned_groups))
+    );
+    learnedGroups = stored || [];
+  } catch { /* ignore */ }
+
   // Check if a URL matches a custom group rule; returns the rule or null
   function matchCustomGroup(url) {
     try {
@@ -1087,6 +1212,15 @@ async function renderStaticDashboard() {
     } catch { return null; }
   }
 
+  function matchLearnedGroup(url) {
+    try {
+      const parsed = new URL(url);
+      return learnedGroups.find(r =>
+        r.rule && r.rule.hostnames && r.rule.hostnames.includes(parsed.hostname)
+      ) || null;
+    } catch { return null; }
+  }
+
   for (const tab of realTabs) {
     try {
       if (isLandingPage(tab.url)) {
@@ -1099,6 +1233,15 @@ async function renderStaticDashboard() {
       if (customRule) {
         const key = customRule.groupKey;
         if (!groupMap[key]) groupMap[key] = { domain: key, label: customRule.groupLabel, tabs: [] };
+        groupMap[key].tabs.push(tab);
+        continue;
+      }
+
+      // Check AI-learned group rules (lower priority than custom groups)
+      const learnedRule = matchLearnedGroup(tab.url);
+      if (learnedRule) {
+        const key = learnedRule.groupKey;
+        if (!groupMap[key]) groupMap[key] = { domain: key, label: learnedRule.groupLabel, tabs: [] };
         groupMap[key].tabs.push(tab);
         continue;
       }
@@ -1150,9 +1293,18 @@ async function renderStaticDashboard() {
 
   if (domainGroups.length > 0 && openTabsSection) {
     if (openTabsSectionTitle) openTabsSectionTitle.textContent = 'Open tabs';
-    openTabsSectionCount.innerHTML = `${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&middot;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button>`;
+    openTabsSectionCount.innerHTML = `${domainGroups.length} domain${domainGroups.length !== 1 ? 's' : ''} &nbsp;&middot;&nbsp; <button class="action-btn close-tabs" data-action="close-all-open-tabs" style="font-size:11px;padding:3px 10px;">${ICONS.close} Close all ${realTabs.length} tabs</button> <button class="action-btn ai-trigger-btn" data-action="trigger-ai" style="font-size:11px;padding:3px 10px;" title="AI 分组建议">✨</button>`;
     openTabsMissionsEl.innerHTML = domainGroups.map(g => renderDomainCard(g)).join('');
     openTabsSection.style.display = 'block';
+
+    // Render AI search input if not already present
+    if (!document.getElementById('aiSearchInput')) {
+      const searchHtml = `<div class="ai-search-container">
+        <input type="text" id="aiSearchInput" class="ai-search-input" placeholder="描述你要找的标签...">
+        <span id="aiSearchStatus" class="ai-search-status"></span>
+      </div>`;
+      openTabsMissionsEl.insertAdjacentHTML('beforebegin', searchHtml);
+    }
   } else if (openTabsSection) {
     openTabsSection.style.display = 'none';
   }
@@ -1170,6 +1322,208 @@ async function renderStaticDashboard() {
 
 async function renderDashboard() {
   await renderStaticDashboard();
+  if (!skipNextAiCall) triggerAiSuggestions();
+  skipNextAiCall = false;
+}
+
+let skipNextAiCall = false;
+let aiAbortController = null;
+
+async function enrichTabsWithMeta(realTabs, tabData) {
+  if (!chrome.scripting?.executeScript) return tabData;
+  const results = await Promise.allSettled(
+    realTabs.map(t => {
+      if (!t.id || t.url.startsWith('file://')) return Promise.resolve(null);
+      return chrome.scripting.executeScript({
+        target: { tabId: t.id },
+        func: () => document.querySelector('meta[name="description"]')?.content || '',
+      }).then(r => r?.[0]?.result || '').catch(() => '');
+    })
+  );
+  return tabData.map((td, i) => {
+    const desc = results[i]?.status === 'fulfilled' ? results[i].value : '';
+    return desc ? { ...td, description: desc.slice(0, 150) } : td;
+  });
+}
+
+async function triggerAiSuggestions() {
+  try {
+    if (aiAbortController) {
+      aiAbortController.abort();
+      aiAbortController = null;
+      await new Promise(r => setTimeout(r, 50));
+    }
+    aiAbortController = new AbortController();
+
+    const settings = await new Promise(resolve =>
+      chrome.storage.local.get('ai_settings', r => resolve(r.ai_settings))
+    );
+    if (!settings || !settings.baseUrl || !settings.apiKey || !settings.model) return;
+
+    const realTabs = openTabs.filter(t => !t.isTabOut && t.url && !t.url.startsWith('chrome'));
+    if (realTabs.length < 3) return;
+
+    const { ai_learned_groups: learnedGroups = [] } = await chrome.storage.local.get('ai_learned_groups');
+    let tabData = realTabs.map(t => ({ title: t.title, url: t.url }));
+    if (settings.metaDesc) {
+      tabData = await enrichTabsWithMeta(realTabs, tabData);
+    }
+    const { suggestions, renames, closeSuggestions } = await fetchGroupingSuggestions(tabData, settings, aiAbortController.signal, learnedGroups);
+
+    const filteredSuggestions = suggestions.filter(s => {
+      if (!s.tabIndices || s.tabIndices.length < 2) return false;
+      const groups = new Set(s.tabIndices.map(idx => {
+        const tab = realTabs[idx - 1];
+        if (!tab) return null;
+        return domainGroups.findIndex(g => g.tabs.some(gt => gt.url === tab.url));
+      }));
+      return groups.size > 1 || groups.has(-1);
+    });
+
+    if (filteredSuggestions.length > 0) renderSuggestionBanners(filteredSuggestions);
+    if (renames && renames.length > 0) applyAiRenames(renames);
+    if (closeSuggestions && closeSuggestions.length > 0) renderCloseSuggestions(closeSuggestions);
+    if (settings.debug) renderDebugPanel();
+  } catch (e) {
+    console.debug('AI suggestions skipped:', e.message);
+  }
+}
+
+function applyAiRenames(renames) {
+  for (const r of renames) {
+    const cards = document.querySelectorAll('.mission-card');
+    for (const card of cards) {
+      const nameEl = card.querySelector('.mission-name');
+      if (nameEl && nameEl.textContent.trim().toLowerCase() === r.original_domain.toLowerCase()) {
+        nameEl.title = nameEl.textContent;
+        nameEl.textContent = r.suggested_name + ' ✨';
+      }
+    }
+  }
+}
+
+function renderDebugPanel() {
+  let panel = document.getElementById('aiDebugPanel');
+  if (!panel) {
+    panel = document.createElement('div');
+    panel.id = 'aiDebugPanel';
+    panel.className = 'ai-debug-panel';
+    document.body.appendChild(panel);
+  }
+
+  const entries = window.__aiDebug || [];
+  const triggerBtns = '<span class="debug-triggers">' +
+    '<button data-action="debug-trigger-ai" data-ai-only="grouping">Grouping</button>' +
+    '<button data-action="debug-trigger-ai" data-ai-only="rename">Rename</button>' +
+    '<button data-action="debug-trigger-ai" data-ai-only="close">Close</button></span>';
+
+  if (entries.length === 0) {
+    panel.innerHTML = '<div class="debug-header">AI Debug ' + triggerBtns + '<button id="debugClose" class="debug-close">✕</button></div><div class="debug-empty">No AI calls yet</div>';
+  } else {
+    panel.innerHTML = '<div class="debug-header">AI Debug (' + entries.length + ' calls) ' + triggerBtns + '<button id="debugClose" class="debug-close">✕</button></div>' +
+      entries.map((e, i) => `<details class="debug-entry">
+        <summary>[${e.type}] ${e.duration}ms — ${new Date(e.timestamp).toLocaleTimeString()}${e.query ? ' — "' + e.query + '"' : ''}</summary>
+        <div class="debug-section"><strong>Prompt:</strong><pre>${JSON.stringify(e.prompt, null, 2).replace(/</g, '&lt;')}</pre></div>
+        <div class="debug-section"><strong>Response:</strong><pre>${(typeof e.response === 'string' ? e.response : JSON.stringify(e.response, null, 2)).replace(/</g, '&lt;')}</pre></div>
+        <div class="debug-section"><strong>Parsed:</strong><pre>${JSON.stringify(e.parsed, null, 2)}</pre></div>
+      </details>`).join('');
+  }
+  panel.style.display = 'block';
+  panel.querySelector('#debugClose')?.addEventListener('click', () => { panel.style.display = 'none'; });
+}
+
+async function triggerAiOnly(mode) {
+  try {
+    if (aiAbortController) {
+      aiAbortController.abort();
+      aiAbortController = null;
+      await new Promise(r => setTimeout(r, 50));
+    }
+    aiAbortController = new AbortController();
+
+    const settings = await new Promise(resolve =>
+      chrome.storage.local.get('ai_settings', r => resolve(r.ai_settings))
+    );
+    if (!settings || !settings.baseUrl || !settings.apiKey || !settings.model) return;
+
+    const realTabs = openTabs.filter(t => !t.isTabOut && t.url && !t.url.startsWith('chrome'));
+    if (realTabs.length < 3) return;
+
+    let tabData = realTabs.map(t => ({ title: t.title, url: t.url }));
+    if (settings.metaDesc) {
+      tabData = await enrichTabsWithMeta(realTabs, tabData);
+    }
+    const { suggestions, renames, closeSuggestions } = await fetchGroupingSuggestions(tabData, settings, aiAbortController.signal);
+
+    if (mode === 'grouping' && suggestions && suggestions.length > 0) {
+      const filtered = suggestions.filter(s => {
+        if (!s.tabIndices || s.tabIndices.length < 2) return false;
+        const groups = new Set(s.tabIndices.map(idx => {
+          const tab = realTabs[idx - 1];
+          if (!tab) return null;
+          return domainGroups.findIndex(g => g.tabs.some(gt => gt.url === tab.url));
+        }));
+        return groups.size > 1 || groups.has(-1);
+      });
+      if (filtered.length > 0) renderSuggestionBanners(filtered);
+    }
+    if (mode === 'rename' && renames && renames.length > 0) applyAiRenames(renames);
+    if (mode === 'close' && closeSuggestions && closeSuggestions.length > 0) renderCloseSuggestions(closeSuggestions);
+
+    renderDebugPanel();
+  } catch (e) {
+    console.debug('AI trigger (' + mode + ') failed:', e.message);
+  }
+}
+
+let searchAbortController = null;
+
+async function searchTabsWithAi(query) {
+  if (!query || query.trim().length < 2) { clearSearchHighlights(); return; }
+
+  const settings = await new Promise(resolve =>
+    chrome.storage.local.get('ai_settings', r => resolve(r.ai_settings))
+  );
+  if (!settings || !settings.baseUrl || !settings.apiKey) return;
+
+  if (searchAbortController) searchAbortController.abort();
+  searchAbortController = new AbortController();
+
+  const realTabs = openTabs.filter(t => !t.isTabOut && t.url && !t.url.startsWith('chrome'));
+  const tabData = realTabs.map(t => ({ title: t.title, url: t.url }));
+
+  const searchArea = document.getElementById('aiSearchStatus');
+  if (searchArea) searchArea.textContent = '搜索中...';
+
+  const matches = await fetchTabSearch(query, tabData, settings, searchAbortController.signal);
+  if (searchArea) searchArea.textContent = '';
+
+  if (matches.length === 0) {
+    if (searchArea) searchArea.textContent = '未找到匹配';
+    setTimeout(() => { if (searchArea) searchArea.textContent = ''; }, 2000);
+    return;
+  }
+
+  highlightMatchedTabs(matches, realTabs);
+  if (settings && settings.debug) renderDebugPanel();
+}
+
+function highlightMatchedTabs(indices, realTabs) {
+  clearSearchHighlights();
+  const matchedUrls = new Set(indices.map(i => realTabs[i - 1]?.url).filter(Boolean));
+
+  document.querySelectorAll('.page-chip[data-tab-url]').forEach(row => {
+    if (matchedUrls.has(row.dataset.tabUrl)) {
+      row.classList.add('tab-highlighted');
+    } else {
+      row.classList.add('tab-dimmed');
+    }
+  });
+}
+
+function clearSearchHighlights() {
+  document.querySelectorAll('.tab-highlighted').forEach(el => el.classList.remove('tab-highlighted'));
+  document.querySelectorAll('.tab-dimmed').forEach(el => el.classList.remove('tab-dimmed'));
 }
 
 
@@ -1187,6 +1541,18 @@ document.addEventListener('click', async (e) => {
   if (!actionEl) return;
 
   const action = actionEl.dataset.action;
+
+  // ---- Trigger AI suggestions manually ----
+  if (action === 'trigger-ai') {
+    triggerAiSuggestions();
+    return;
+  }
+
+  // ---- Debug: trigger single AI capability ----
+  if (action === 'debug-trigger-ai') {
+    triggerAiOnly(actionEl.dataset.aiOnly);
+    return;
+  }
 
   // ---- Close duplicate Tab Out tabs ----
   if (action === 'close-tabout-dupes') {
@@ -1229,7 +1595,7 @@ document.addEventListener('click', async (e) => {
 
     // Close the tab in Chrome directly
     const allTabs = await chrome.tabs.query({});
-    const match   = allTabs.find(t => t.url === tabUrl);
+    const match = allTabs.find(t => t.url === tabUrl || extractSuspendedUrl(t.url) === tabUrl);
     if (match) await chrome.tabs.remove(match.id);
     await fetchOpenTabs();
 
@@ -1412,6 +1778,99 @@ document.addEventListener('click', async (e) => {
     return;
   }
 
+  // ---- Accept AI suggestion ----
+  if (action === 'accept-suggestion') {
+    const banner = actionEl.closest('.ai-suggestion-banner');
+    if (banner && pendingSuggestions.length > 0) {
+      const suggestion = pendingSuggestions[0];
+      const realTabs = openTabs.filter(t => !t.isTabOut && t.url && !t.url.startsWith('chrome'));
+      const hostnames = [...new Set(
+        suggestion.tabIndices
+          .map(i => realTabs[i - 1])
+          .filter(Boolean)
+          .map(t => { try { return new URL(t.url).hostname; } catch { return null; } })
+          .filter(Boolean)
+      )];
+
+      const rule = {
+        groupKey: 'ai_' + suggestion.groupLabel.toLowerCase().replace(/[^a-z0-9]+/g, '_'),
+        groupLabel: suggestion.groupLabel,
+        rule: { hostnames },
+        createdAt: Date.now()
+      };
+
+      const { ai_learned_groups: groups = [] } = await chrome.storage.local.get('ai_learned_groups');
+      groups.push(rule);
+      await chrome.storage.local.set({ ai_learned_groups: groups });
+
+      banner.classList.add('hiding');
+      setTimeout(() => {
+        banner.remove();
+        pendingSuggestions.shift();
+        renderNextSuggestionBanner();
+        if (pendingSuggestions.length === 0) renderNextCloseBanner();
+        skipNextAiCall = true;
+        renderDashboard();
+      }, 300);
+      showToast(`已添加分组规则：${suggestion.groupLabel}`);
+    }
+    return;
+  }
+
+  // ---- Dismiss AI suggestion ----
+  if (action === 'dismiss-suggestion') {
+    const banner = actionEl.closest('.ai-suggestion-banner');
+    if (banner) {
+      banner.classList.add('hiding');
+      setTimeout(() => {
+        banner.remove();
+        pendingSuggestions.shift();
+        renderNextSuggestionBanner();
+        if (pendingSuggestions.length === 0) renderNextCloseBanner();
+      }, 300);
+    }
+    return;
+  }
+
+  // ---- Accept close suggestion ----
+  if (action === 'accept-close-suggestion') {
+    const banner = actionEl.closest('.ai-close-banner');
+    if (banner && pendingCloseSuggestions.length > 0) {
+      const suggestion = pendingCloseSuggestions[0];
+      const realTabs = openTabs.filter(t => !t.isTabOut && t.url && !t.url.startsWith('chrome'));
+      const urlsToClose = suggestion.tabIndices
+        .map(i => realTabs[i - 1])
+        .filter(Boolean)
+        .map(t => t.url);
+
+      await closeTabsExact(urlsToClose);
+      playCloseSound();
+
+      banner.classList.add('hiding');
+      setTimeout(() => {
+        banner.remove();
+        pendingCloseSuggestions.shift();
+        renderNextCloseBanner();
+      }, 300);
+      showToast(`已关闭 ${urlsToClose.length} 个标签`);
+    }
+    return;
+  }
+
+  // ---- Dismiss close suggestion ----
+  if (action === 'dismiss-close-suggestion') {
+    const banner = actionEl.closest('.ai-close-banner');
+    if (banner) {
+      banner.classList.add('hiding');
+      setTimeout(() => {
+        banner.remove();
+        pendingCloseSuggestions.shift();
+        renderNextCloseBanner();
+      }, 300);
+    }
+    return;
+  }
+
   // ---- Close ALL open tabs ----
   if (action === 'close-all-open-tabs') {
     const allUrls = openTabs
@@ -1479,4 +1938,16 @@ document.addEventListener('input', async (e) => {
 /* ----------------------------------------------------------------
    INITIALIZE
    ---------------------------------------------------------------- */
+document.addEventListener('input', (e) => {
+  if (e.target.id !== 'aiSearchInput') return;
+  clearTimeout(e.target._debounce);
+  e.target._debounce = setTimeout(() => searchTabsWithAi(e.target.value), 500);
+});
+
+document.addEventListener('keydown', (e) => {
+  if (e.target.id !== 'aiSearchInput') return;
+  if (e.key === 'Enter') { clearTimeout(e.target._debounce); searchTabsWithAi(e.target.value); }
+  if (e.key === 'Escape') { e.target.value = ''; clearSearchHighlights(); }
+});
+
 renderDashboard();

--- a/extension/app.js
+++ b/extension/app.js
@@ -26,6 +26,30 @@
 // All open tabs — populated by fetchOpenTabs()
 let openTabs = [];
 
+// Bookmarked URLs cache — loaded once, refreshed on bookmark changes
+let bookmarkUrlSet = new Set();
+
+async function loadBookmarks(forceRefresh = false) {
+  if (!forceRefresh) {
+    const { bookmarkUrlCache } = await chrome.storage.local.get('bookmarkUrlCache');
+    if (bookmarkUrlCache) { bookmarkUrlSet = new Set(bookmarkUrlCache); return; }
+  }
+  const tree = await chrome.bookmarks.getTree();
+  const urls = [];
+  (function walk(nodes) {
+    for (const n of nodes) {
+      if (n.url) urls.push(n.url);
+      if (n.children) walk(n.children);
+    }
+  })(tree);
+  bookmarkUrlSet = new Set(urls);
+  await chrome.storage.local.set({ bookmarkUrlCache: urls });
+}
+
+chrome.bookmarks.onCreated.addListener(() => loadBookmarks(true));
+chrome.bookmarks.onRemoved.addListener(() => loadBookmarks(true));
+chrome.bookmarks.onChanged.addListener(() => loadBookmarks(true));
+
 function extractSuspendedUrl(url) {
   if (!url || !url.startsWith('chrome-extension://')) return null;
   try {
@@ -458,6 +482,26 @@ function showToast(message) {
   setTimeout(() => toast.classList.remove('visible'), 2500);
 }
 
+function showConfirm(message) {
+  return new Promise(resolve => {
+    const overlay = document.getElementById('confirmOverlay');
+    document.getElementById('confirmMsg').textContent = message;
+    overlay.classList.add('visible');
+    const cleanup = (result) => {
+      overlay.classList.remove('visible');
+      okBtn.removeEventListener('click', onOk);
+      cancelBtn.removeEventListener('click', onCancel);
+      resolve(result);
+    };
+    const onOk = () => cleanup(true);
+    const onCancel = () => cleanup(false);
+    const okBtn = document.getElementById('confirmOk');
+    const cancelBtn = document.getElementById('confirmCancel');
+    okBtn.addEventListener('click', onOk);
+    cancelBtn.addEventListener('click', onCancel);
+  });
+}
+
 /**
  * checkAndShowEmptyState()
  *
@@ -886,7 +930,7 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
     const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
       ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}
+      ${bookmarkUrlSet.has(tab.url) ? '<span class="chip-bookmark">⭐</span>' : ''}<span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
@@ -967,7 +1011,7 @@ function renderDomainCard(group) {
     const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
       ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}
+      ${bookmarkUrlSet.has(tab.url) ? '<span class="chip-bookmark">⭐</span>' : ''}<span class="chip-text">${label}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
@@ -1144,6 +1188,7 @@ async function renderStaticDashboard() {
 
   // --- Fetch tabs ---
   await fetchOpenTabs();
+  await loadBookmarks();
   const realTabs = getRealTabs();
 
   // --- Group tabs by domain ---
@@ -1851,6 +1896,8 @@ document.addEventListener('click', async (e) => {
         banner.remove();
         pendingCloseSuggestions.shift();
         renderNextCloseBanner();
+        skipNextAiCall = true;
+        renderDashboard();
       }, 300);
       showToast(`已关闭 ${urlsToClose.length} 个标签`);
     }
@@ -1876,6 +1923,9 @@ document.addEventListener('click', async (e) => {
     const allUrls = openTabs
       .filter(t => t.url && !t.url.startsWith('chrome') && !t.url.startsWith('about:'))
       .map(t => t.url);
+    const count = allUrls.length;
+    const confirmed = await showConfirm(`This will close all ${count} tab${count !== 1 ? 's' : ''}. Are you sure?`);
+    if (!confirmed) return;
     await closeTabsByUrls(allUrls);
     playCloseSound();
 

--- a/extension/app.js
+++ b/extension/app.js
@@ -1366,26 +1366,52 @@ async function renderStaticDashboard() {
 }
 
 async function renderFrequentSites() {
-  const { frequentSites } = await chrome.storage.local.get('frequentSites');
+  const { frequentSites, frequentBlacklist = [] } = await chrome.storage.local.get(['frequentSites', 'frequentBlacklist']);
   const container = document.getElementById('frequentSitesSection');
   if (!container) return;
   if (!frequentSites || frequentSites.length === 0) {
     container.style.display = 'none';
     return;
   }
+  const blacklistSet = new Set(frequentBlacklist);
+  const visible = frequentSites.filter(s => !blacklistSet.has(s.hostname));
+  if (visible.length === 0) {
+    container.style.display = 'none';
+    return;
+  }
   container.style.display = 'block';
   const listEl = document.getElementById('frequentSitesList');
-  listEl.innerHTML = frequentSites.map(s => {
+  listEl.innerHTML = visible.map(s => {
     const favicon = `https://www.google.com/s2/favicons?domain=${s.hostname}&sz=32`;
     const label = s.title.length > 24 ? s.title.slice(0, 22) + '…' : s.title;
-    return `<a class="freq-chip" href="${s.url}" data-freq-url="${s.url}" title="${s.title}">
+    return `<a class="freq-chip" href="${s.url}" data-freq-url="${s.url}" data-freq-host="${s.hostname}" title="${s.title}">
       <img class="freq-favicon" src="${favicon}" width="16" height="16" alt="">
       <span class="freq-label">${label}</span>
+      <button class="freq-dismiss" data-action="dismiss-freq" title="不再显示">×</button>
     </a>`;
   }).join('');
 }
 
-document.addEventListener('click', e => {
+document.addEventListener('click', async e => {
+  if (e.target.closest('[data-action="dismiss-freq"]')) {
+    e.preventDefault();
+    e.stopPropagation();
+    const chip = e.target.closest('.freq-chip');
+    if (!chip) return;
+    const host = chip.dataset.freqHost;
+    if (!host) return;
+    const { frequentBlacklist = [] } = await chrome.storage.local.get('frequentBlacklist');
+    if (!frequentBlacklist.includes(host)) {
+      frequentBlacklist.push(host);
+      await chrome.storage.local.set({ frequentBlacklist });
+    }
+    chip.style.transition = 'opacity 0.2s, transform 0.2s';
+    chip.style.opacity = '0';
+    chip.style.transform = 'scale(0.9)';
+    setTimeout(() => { chip.remove(); renderFrequentSites(); }, 200);
+    if (typeof showToast === 'function') showToast(`已屏蔽 ${host}`);
+    return;
+  }
   const chip = e.target.closest('.freq-chip');
   if (!chip) return;
   e.preventDefault();
@@ -1588,7 +1614,11 @@ async function searchTabsWithAi(query) {
   let historyData = [];
   try {
     const historyRaw = await chrome.history.search({ text: query, maxResults: 30 });
-    const historyDeduped = (historyRaw || []).filter(h => h.url && !openUrls.has(h.url));
+    const historyDeduped = (historyRaw || []).filter(h => {
+      if (!h.url) return false;
+      if (h.url.startsWith('chrome-extension://') || h.url.startsWith('chrome://')) return false;
+      return !openUrls.has(h.url);
+    });
     historyData = historyDeduped.slice(0, 20).map(h => ({ title: h.title || h.url, url: h.url }));
   } catch (e) {
     console.warn('[Tab Out] chrome.history.search failed:', e);
@@ -1644,13 +1674,13 @@ function renderHistoryResults(indices, historyData) {
     }).join('');
 
   const html = `<div class="history-results-section" id="historyResultsSection">
-    <div class="history-results-header">History</div>
+    <div class="section-header"><h2>History</h2><div class="section-line"></div></div>
     ${items}
   </div>`;
 
-  const openSection = document.getElementById('openTabsSection');
-  if (openSection) {
-    openSection.insertAdjacentHTML('afterend', html);
+  const topRow = document.getElementById('topRow');
+  if (topRow) {
+    topRow.insertAdjacentHTML('beforeend', html);
   }
 
   document.getElementById('historyResultsSection').addEventListener('click', (e) => {

--- a/extension/app.js
+++ b/extension/app.js
@@ -1365,8 +1365,52 @@ async function renderStaticDashboard() {
   await renderDeferredColumn();
 }
 
+async function renderFrequentSites() {
+  const { frequentSites } = await chrome.storage.local.get('frequentSites');
+  const container = document.getElementById('frequentSitesSection');
+  if (!container) return;
+  if (!frequentSites || frequentSites.length === 0) {
+    container.style.display = 'none';
+    return;
+  }
+  container.style.display = 'block';
+  const listEl = document.getElementById('frequentSitesList');
+  listEl.innerHTML = frequentSites.map(s => {
+    const favicon = `https://www.google.com/s2/favicons?domain=${s.hostname}&sz=32`;
+    const label = s.title.length > 24 ? s.title.slice(0, 22) + '…' : s.title;
+    return `<a class="freq-chip" href="${s.url}" data-freq-url="${s.url}" title="${s.title}">
+      <img class="freq-favicon" src="${favicon}" width="16" height="16" alt="">
+      <span class="freq-label">${label}</span>
+    </a>`;
+  }).join('');
+}
+
+document.addEventListener('click', e => {
+  const chip = e.target.closest('.freq-chip');
+  if (!chip) return;
+  e.preventDefault();
+  const url = chip.dataset.freqUrl;
+  focusOrOpen(url);
+});
+
+async function focusOrOpen(url) {
+  const allTabs = await chrome.tabs.query({});
+  let hostname;
+  try { hostname = new URL(url).hostname; } catch { return; }
+  const match = allTabs.find(t => {
+    try { return new URL(t.url).hostname === hostname; } catch { return false; }
+  });
+  if (match) {
+    await chrome.tabs.update(match.id, { active: true });
+    await chrome.windows.update(match.windowId, { focused: true });
+  } else {
+    await chrome.tabs.create({ url });
+  }
+}
+
 async function renderDashboard() {
   await renderStaticDashboard();
+  await renderFrequentSites();
   if (!skipNextAiCall) triggerAiSuggestions();
   skipNextAiCall = false;
 }
@@ -1524,7 +1568,7 @@ async function triggerAiOnly(mode) {
 let searchAbortController = null;
 
 async function searchTabsWithAi(query) {
-  if (!query || query.trim().length < 2) { clearSearchHighlights(); return; }
+  if (!query || query.trim().length < 2) { clearSearchHighlights(); clearHistoryResults(); return; }
 
   const settings = await new Promise(resolve =>
     chrome.storage.local.get('ai_settings', r => resolve(r.ai_settings))
@@ -1540,16 +1584,28 @@ async function searchTabsWithAi(query) {
   const searchArea = document.getElementById('aiSearchStatus');
   if (searchArea) searchArea.textContent = '搜索中...';
 
-  const matches = await fetchTabSearch(query, tabData, settings, searchAbortController.signal);
+  const openUrls = new Set(realTabs.map(t => t.url));
+  let historyData = [];
+  try {
+    const historyRaw = await chrome.history.search({ text: query, maxResults: 30 });
+    const historyDeduped = (historyRaw || []).filter(h => h.url && !openUrls.has(h.url));
+    historyData = historyDeduped.slice(0, 20).map(h => ({ title: h.title || h.url, url: h.url }));
+  } catch (e) {
+    console.warn('[Tab Out] chrome.history.search failed:', e);
+  }
+
+  const { openMatches, historyMatches } = await fetchTabSearch(query, tabData, historyData, settings, searchAbortController.signal);
   if (searchArea) searchArea.textContent = '';
 
-  if (matches.length === 0) {
+  if (openMatches.length === 0 && historyMatches.length === 0) {
     if (searchArea) searchArea.textContent = '未找到匹配';
     setTimeout(() => { if (searchArea) searchArea.textContent = ''; }, 2000);
+    clearHistoryResults();
     return;
   }
 
-  highlightMatchedTabs(matches, realTabs);
+  highlightMatchedTabs(openMatches, realTabs);
+  renderHistoryResults(historyMatches, historyData);
   if (settings && settings.debug) renderDebugPanel();
 }
 
@@ -1569,6 +1625,43 @@ function highlightMatchedTabs(indices, realTabs) {
 function clearSearchHighlights() {
   document.querySelectorAll('.tab-highlighted').forEach(el => el.classList.remove('tab-highlighted'));
   document.querySelectorAll('.tab-dimmed').forEach(el => el.classList.remove('tab-dimmed'));
+}
+
+function renderHistoryResults(indices, historyData) {
+  clearHistoryResults();
+  if (!indices || indices.length === 0) return;
+
+  const items = indices
+    .map(i => historyData[i - 1])
+    .filter(Boolean)
+    .map(h => {
+      const hostname = new URL(h.url).hostname.replace('www.', '');
+      return `<div class="history-result-item" data-url="${h.url.replace(/"/g, '&quot;')}">
+        <img class="chip-favicon" src="https://www.google.com/s2/favicons?domain=${hostname}&sz=32" alt="">
+        <span class="history-result-title">${h.title || hostname}</span>
+        <span class="history-result-host">${hostname}</span>
+      </div>`;
+    }).join('');
+
+  const html = `<div class="history-results-section" id="historyResultsSection">
+    <div class="history-results-header">History</div>
+    ${items}
+  </div>`;
+
+  const openSection = document.getElementById('openTabsSection');
+  if (openSection) {
+    openSection.insertAdjacentHTML('afterend', html);
+  }
+
+  document.getElementById('historyResultsSection').addEventListener('click', (e) => {
+    const item = e.target.closest('.history-result-item');
+    if (item) chrome.tabs.create({ url: item.dataset.url });
+  });
+}
+
+function clearHistoryResults() {
+  const el = document.getElementById('historyResultsSection');
+  if (el) el.remove();
 }
 
 
@@ -1997,7 +2090,7 @@ document.addEventListener('input', (e) => {
 document.addEventListener('keydown', (e) => {
   if (e.target.id !== 'aiSearchInput') return;
   if (e.key === 'Enter') { clearTimeout(e.target._debounce); searchTabsWithAi(e.target.value); }
-  if (e.key === 'Escape') { e.target.value = ''; clearSearchHighlights(); }
+  if (e.key === 'Escape') { e.target.value = ''; clearSearchHighlights(); clearHistoryResults(); }
 });
 
 renderDashboard();

--- a/extension/background.js
+++ b/extension/background.js
@@ -21,13 +21,39 @@
  * Counts open real-web tabs and updates the extension's toolbar badge.
  * "Real" tabs = not chrome://, not extension pages, not about:blank.
  */
+/**
+ * extractSuspendedUrl(url)
+ *
+ * Detects tabs suspended by Tab Suspender extensions and extracts the original URL.
+ */
+function extractSuspendedUrl(url) {
+  if (!url || !url.startsWith('chrome-extension://')) return null;
+  try {
+    const parsed = new URL(url);
+    for (const key of ['url', 'uri']) {
+      const val = parsed.searchParams.get(key);
+      if (val && (val.startsWith('http://') || val.startsWith('https://') || val.startsWith('file://'))) return val;
+    }
+    const hash = parsed.hash.slice(1);
+    if (hash) {
+      const params = new URLSearchParams(hash);
+      for (const key of ['uri', 'url']) {
+        const val = params.get(key);
+        if (val && (val.startsWith('http://') || val.startsWith('https://') || val.startsWith('file://'))) return val;
+      }
+    }
+  } catch {}
+  return null;
+}
+
 async function updateBadge() {
   try {
     const tabs = await chrome.tabs.query({});
 
-    // Only count actual web pages — skip browser internals and extension pages
     const count = tabs.filter(t => {
       const url = t.url || '';
+      // Suspended tabs count as real tabs
+      if (extractSuspendedUrl(url)) return true;
       return (
         !url.startsWith('chrome://') &&
         !url.startsWith('chrome-extension://') &&

--- a/extension/background.js
+++ b/extension/background.js
@@ -113,6 +113,88 @@ chrome.tabs.onUpdated.addListener(() => {
   updateBadge();
 });
 
+// ─── Frequent Sites Prediction ───────────────────────────────────────────────
+
+const PREDICTION_ALARM = 'compute-frequent-sites';
+const PREDICTION_WINDOW_MS = 48 * 60 * 60 * 1000; // 48 hours
+const PREDICTION_INTERVAL_MIN = 180; // 3 hours
+const PREDICTION_TOP_N = 8;
+
+chrome.alarms.onAlarm.addListener(alarm => {
+  if (alarm.name === PREDICTION_ALARM) computeFrequentSites();
+});
+
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.alarms.create(PREDICTION_ALARM, { periodInMinutes: PREDICTION_INTERVAL_MIN });
+  computeFrequentSites();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+  chrome.alarms.create(PREDICTION_ALARM, { periodInMinutes: PREDICTION_INTERVAL_MIN });
+  computeFrequentSites();
+});
+
+async function computeFrequentSites() {
+  try {
+    const now = Date.now();
+    const since = now - PREDICTION_WINDOW_MS;
+    const hour = new Date().getHours();
+    const currentSlot = Math.floor(hour / 3); // 0-7, 8 slots per day
+
+    const items = await chrome.history.search({
+      text: '',
+      startTime: since,
+      endTime: now,
+      maxResults: 5000,
+    });
+
+    // Score by visit count weighted by time-slot match
+    const siteScores = {};
+    for (const item of items) {
+      if (!item.url || item.url.startsWith('chrome://') || item.url.startsWith('chrome-extension://')) continue;
+      let hostname;
+      try { hostname = new URL(item.url).hostname; } catch { continue; }
+      if (!hostname) continue;
+
+      const visitSlot = item.lastVisitTime ? Math.floor(new Date(item.lastVisitTime).getHours() / 3) : -1;
+      const slotBonus = visitSlot === currentSlot ? 2.0 : 1.0;
+      const visitCount = item.visitCount || 1;
+
+      if (!siteScores[hostname]) siteScores[hostname] = { hostname, score: 0, url: item.url, title: item.title };
+      siteScores[hostname].score += visitCount * slotBonus;
+      // Keep the most-visited URL for this hostname
+      if (visitCount > (siteScores[hostname]._maxVisits || 0)) {
+        siteScores[hostname]._maxVisits = visitCount;
+        siteScores[hostname].url = item.url;
+        siteScores[hostname].title = item.title;
+      }
+    }
+
+    // Filter out currently open tabs
+    const openTabs = await chrome.tabs.query({});
+    const openHostnames = new Set();
+    for (const t of openTabs) {
+      try {
+        const u = extractSuspendedUrl(t.url) || t.url;
+        if (u) openHostnames.add(new URL(u).hostname);
+      } catch {}
+    }
+
+    const candidates = Object.values(siteScores)
+      .filter(s => !openHostnames.has(s.hostname))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, PREDICTION_TOP_N)
+      .map(s => ({ hostname: s.hostname, url: s.url, title: s.title || s.hostname, score: s.score }));
+
+    await chrome.storage.local.set({
+      frequentSites: candidates,
+      frequentSitesUpdatedAt: now,
+    });
+  } catch (e) {
+    // Silently fail — non-critical feature
+  }
+}
+
 // ─── Initial run ─────────────────────────────────────────────────────────────
 
 // Run once immediately when the service worker first loads

--- a/extension/index.html
+++ b/extension/index.html
@@ -62,6 +62,15 @@
        ================================================================ -->
   <div class="dashboard-columns" id="dashboardColumns">
 
+    <!-- FREQUENT SITES — predicted based on 48h history -->
+    <div class="frequent-section" id="frequentSitesSection" style="display:none">
+      <div class="section-header">
+        <h2>Might open next</h2>
+        <div class="section-line"></div>
+      </div>
+      <div class="frequent-list" id="frequentSitesList"></div>
+    </div>
+
     <!-- LEFT COLUMN: Open tabs -->
     <div class="active-section" id="openTabsSection" style="display:none">
       <div class="section-header">

--- a/extension/index.html
+++ b/extension/index.html
@@ -122,6 +122,19 @@
 </div><!-- end .container -->
 
 <!-- ================================================================
+     CONFIRM MODAL — for dangerous operations (close all tabs, etc.)
+     ================================================================ -->
+<div class="confirm-overlay" id="confirmOverlay">
+  <div class="confirm-dialog">
+    <p class="confirm-msg" id="confirmMsg"></p>
+    <div class="confirm-actions">
+      <button class="confirm-btn confirm-cancel" id="confirmCancel">Cancel</button>
+      <button class="confirm-btn confirm-danger" id="confirmOk">Close All</button>
+    </div>
+  </div>
+</div>
+
+<!-- ================================================================
      TOAST — floats above everything, used for action confirmations
      Hidden by default via CSS (opacity:0, translateY)
      ================================================================ -->

--- a/extension/index.html
+++ b/extension/index.html
@@ -26,6 +26,14 @@
       <!-- "Friday, April 4, 2026" — written by getDateDisplay() in app.js -->
       <div class="date" id="dateDisplay"></div>
     </div>
+    <div class="header-right">
+      <button class="settings-btn" id="settingsBtn" title="Settings">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.248a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+        </svg>
+      </button>
+    </div>
   </header>
 
   <!-- ================================================================
@@ -129,6 +137,8 @@
 <!-- If the file doesn't exist, that's fine — app.js uses sensible defaults. -->
 <script src="config.local.js" onerror="/* no personal config, that's fine */"></script>
 
+<script src="settings.js"></script>
+<script src="ai-api.js"></script>
 <!-- Main dashboard logic — loads last so the DOM is ready -->
 <script src="app.js"></script>
 </body>

--- a/extension/index.html
+++ b/extension/index.html
@@ -17,26 +17,6 @@
 
 
   <!-- ================================================================
-       HEADER — greeting on the left
-       ================================================================ -->
-  <header>
-    <div class="header-left">
-      <!-- "Good afternoon" — written by getGreeting() in app.js -->
-      <h1 id="greeting"></h1>
-      <!-- "Friday, April 4, 2026" — written by getDateDisplay() in app.js -->
-      <div class="date" id="dateDisplay"></div>
-    </div>
-    <div class="header-right">
-      <button class="settings-btn" id="settingsBtn" title="Settings">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="20" height="20">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.248a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-        </svg>
-      </button>
-    </div>
-  </header>
-
-  <!-- ================================================================
        TAB OUT DUPES BANNER — appears when you have extra Tab Out tabs open
        Hidden by default; app.js shows it when dupeTabOutCount > 1
        ================================================================ -->
@@ -60,9 +40,8 @@
        Right: saved for later checklist
        The right column only renders when it has items (JS controls this)
        ================================================================ -->
-  <div class="dashboard-columns" id="dashboardColumns">
-
-    <!-- FREQUENT SITES — predicted based on 48h history -->
+  <!-- Top row: Might open next + History (side by side) -->
+  <div class="top-row" id="topRow">
     <div class="frequent-section" id="frequentSitesSection" style="display:none">
       <div class="section-header">
         <h2>Might open next</h2>
@@ -70,6 +49,10 @@
       </div>
       <div class="frequent-list" id="frequentSitesList"></div>
     </div>
+  </div>
+
+  <!-- Bottom row: Open tabs + Saved for later (side by side) -->
+  <div class="dashboard-columns" id="dashboardColumns">
 
     <!-- LEFT COLUMN: Open tabs -->
     <div class="active-section" id="openTabsSection" style="display:none">
@@ -125,6 +108,12 @@
     </div>
     <div class="last-refresh">
       <span style="color: var(--muted); font-size: 11px;"><a href="https://github.com/zarazhangrui/tab-out" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Tab Out</a> by <a href="https://x.com/zarazhangrui" target="_top" style="color: var(--muted); text-decoration: underline; text-underline-offset: 2px;">Zara</a></span>
+      <button class="settings-btn" id="settingsBtn" title="Settings" style="margin-left: 12px;">
+        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" width="16" height="16">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.248a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+        </svg>
+      </button>
     </div>
   </footer>
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tab Out",
   "version": "1.0.0",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
-  "permissions": ["tabs", "activeTab", "storage", "scripting", "bookmarks"],
+  "permissions": ["tabs", "activeTab", "storage", "scripting", "bookmarks", "history", "alarms"],
   "host_permissions": ["https://*/*", "http://*/*"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,8 @@
   "name": "Tab Out",
   "version": "1.0.0",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
-  "permissions": ["tabs", "activeTab", "storage"],
+  "permissions": ["tabs", "activeTab", "storage", "scripting"],
+  "host_permissions": ["https://*/*", "http://*/*"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },
   "action": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tab Out",
   "version": "1.0.0",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
-  "permissions": ["tabs", "activeTab", "storage", "scripting"],
+  "permissions": ["tabs", "activeTab", "storage", "scripting", "bookmarks"],
   "host_permissions": ["https://*/*", "http://*/*"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -29,6 +29,10 @@ function openSettings() {
       <label class="settings-debug-label"><input type="checkbox" id="settingsDebug"> Debug Mode</label>
       <label class="settings-debug-label"><input type="checkbox" id="settingsMetaDesc"> Include Meta Description</label>
       <button class="settings-test-ai" id="settingsTestAiBtn">Test AI</button>
+      <div class="settings-blacklist-section" id="settingsBlacklistSection">
+        <label>已屏蔽的网站（不再出现在 Might open next）</label>
+        <div class="blacklist-list" id="settingsBlacklistList"></div>
+      </div>
     </div>
   `;
 
@@ -39,6 +43,17 @@ function openSettings() {
     closeSettings();
     if (typeof triggerAiSuggestions === 'function') triggerAiSuggestions();
     setTimeout(() => { if (typeof renderDebugPanel === 'function') renderDebugPanel(); }, 500);
+  });
+  overlay.addEventListener('click', async (e) => {
+    const btn = e.target.closest('[data-action="unblock-freq"]');
+    if (!btn) return;
+    const host = btn.dataset.host;
+    const { frequentBlacklist = [] } = await chrome.storage.local.get('frequentBlacklist');
+    const updated = frequentBlacklist.filter(h => h !== host);
+    await chrome.storage.local.set({ frequentBlacklist: updated });
+    renderBlacklist();
+    if (typeof renderFrequentSites === 'function') renderFrequentSites();
+    if (typeof showToast === 'function') showToast(`已恢复 ${host}`);
   });
   loadSettings();
 }
@@ -74,6 +89,21 @@ function loadSettings() {
     const metaDescEl = document.getElementById('settingsMetaDesc');
     if (metaDescEl) metaDescEl.checked = !!s.metaDesc;
   });
+  renderBlacklist();
+}
+
+async function renderBlacklist() {
+  const listEl = document.getElementById('settingsBlacklistList');
+  if (!listEl) return;
+  const { frequentBlacklist = [] } = await chrome.storage.local.get('frequentBlacklist');
+  if (frequentBlacklist.length === 0) {
+    listEl.innerHTML = '<div class="blacklist-empty">暂无屏蔽项</div>';
+    return;
+  }
+  listEl.innerHTML = frequentBlacklist.map(host => `<div class="blacklist-item">
+    <span class="blacklist-host">${host}</span>
+    <button class="blacklist-remove" data-action="unblock-freq" data-host="${host}" title="恢复显示">×</button>
+  </div>`).join('');
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/extension/settings.js
+++ b/extension/settings.js
@@ -1,0 +1,82 @@
+function openSettings() {
+  let panel = document.getElementById('settingsOverlay');
+  if (panel) {
+    panel.style.display = 'flex';
+    loadSettings();
+    return;
+  }
+
+  const overlay = document.createElement('div');
+  overlay.id = 'settingsOverlay';
+  overlay.className = 'settings-overlay';
+  overlay.addEventListener('click', function(e) {
+    if (e.target === overlay) closeSettings();
+  });
+
+  overlay.innerHTML = `
+    <div class="settings-panel">
+      <h2 class="settings-title">AI Settings</h2>
+      <label for="settingsBaseUrl">Base URL</label>
+      <input type="text" id="settingsBaseUrl" placeholder="https://api.openai.com/v1">
+      <label for="settingsApiKey">API Key</label>
+      <input type="password" id="settingsApiKey" placeholder="sk-...">
+      <label for="settingsModel">Model</label>
+      <input type="text" id="settingsModel" placeholder="gpt-4o">
+      <div class="settings-actions">
+        <button class="settings-cancel" id="settingsCancelBtn">Cancel</button>
+        <button class="settings-save" id="settingsSaveBtn">Save</button>
+      </div>
+      <label class="settings-debug-label"><input type="checkbox" id="settingsDebug"> Debug Mode</label>
+      <label class="settings-debug-label"><input type="checkbox" id="settingsMetaDesc"> Include Meta Description</label>
+      <button class="settings-test-ai" id="settingsTestAiBtn">Test AI</button>
+    </div>
+  `;
+
+  document.body.appendChild(overlay);
+  document.getElementById('settingsCancelBtn').addEventListener('click', closeSettings);
+  document.getElementById('settingsSaveBtn').addEventListener('click', saveSettings);
+  document.getElementById('settingsTestAiBtn').addEventListener('click', () => {
+    closeSettings();
+    if (typeof triggerAiSuggestions === 'function') triggerAiSuggestions();
+    setTimeout(() => { if (typeof renderDebugPanel === 'function') renderDebugPanel(); }, 500);
+  });
+  loadSettings();
+}
+
+function closeSettings() {
+  const overlay = document.getElementById('settingsOverlay');
+  if (overlay) overlay.style.display = 'none';
+}
+
+function saveSettings() {
+  const baseUrl = document.getElementById('settingsBaseUrl').value.trim();
+  const apiKey = document.getElementById('settingsApiKey').value.trim();
+  const model = document.getElementById('settingsModel').value.trim();
+
+  chrome.storage.local.set({ ai_settings: { baseUrl, apiKey, model, debug: document.getElementById('settingsDebug').checked, metaDesc: document.getElementById('settingsMetaDesc').checked } }, function() {
+    closeSettings();
+    if (typeof showToast === 'function') showToast('Settings saved');
+    if (document.getElementById('settingsDebug').checked && typeof renderDebugPanel === 'function') renderDebugPanel();
+  });
+}
+
+function loadSettings() {
+  chrome.storage.local.get('ai_settings', function(result) {
+    const s = result.ai_settings || {};
+    const urlEl = document.getElementById('settingsBaseUrl');
+    const keyEl = document.getElementById('settingsApiKey');
+    const modelEl = document.getElementById('settingsModel');
+    if (urlEl) urlEl.value = s.baseUrl || '';
+    if (keyEl) keyEl.value = s.apiKey || '';
+    if (modelEl) modelEl.value = s.model || '';
+    const debugEl = document.getElementById('settingsDebug');
+    if (debugEl) debugEl.checked = !!s.debug;
+    const metaDescEl = document.getElementById('settingsMetaDesc');
+    if (metaDescEl) metaDescEl.checked = !!s.metaDesc;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('settingsBtn');
+  if (btn) btn.addEventListener('click', openSettings);
+});

--- a/extension/style.css
+++ b/extension/style.css
@@ -384,6 +384,11 @@ header {
   border-radius: 2px;
 }
 
+.chip-bookmark {
+  font-size: 10px;
+  flex-shrink: 0;
+}
+
 /* Title text — wraps naturally, no truncation */
 .chip-text {
   flex: 1;
@@ -1584,4 +1589,71 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   background: var(--accent-amber);
   color: #000;
   border-color: var(--accent-amber);
+}
+
+/* ---- Confirm Dialog ---- */
+.confirm-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 22, 19, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s;
+}
+.confirm-overlay.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+.confirm-dialog {
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray);
+  border-radius: 12px;
+  padding: 24px 28px;
+  max-width: 340px;
+  box-shadow: 0 8px 32px rgba(26, 22, 19, 0.18);
+  transform: scale(0.95);
+  transition: transform .2s;
+}
+.confirm-overlay.visible .confirm-dialog {
+  transform: scale(1);
+}
+.confirm-msg {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--ink);
+  margin-bottom: 20px;
+}
+.confirm-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+.confirm-btn {
+  padding: 7px 16px;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid var(--warm-gray);
+  transition: background .15s, border-color .15s;
+}
+.confirm-cancel {
+  background: var(--paper);
+  color: var(--ink);
+}
+.confirm-cancel:hover {
+  background: var(--warm-gray);
+}
+.confirm-danger {
+  background: var(--accent-rose);
+  color: #fff;
+  border-color: var(--accent-rose);
+}
+.confirm-danger:hover {
+  background: #9a4444;
+  border-color: #9a4444;
 }

--- a/extension/style.css
+++ b/extension/style.css
@@ -1457,6 +1457,57 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   transition: opacity 0.3s;
 }
 
+/* History search results */
+.history-results-section {
+  margin-top: 20px;
+  padding-top: 16px;
+  border-top: 1px solid rgba(154, 145, 138, 0.15);
+}
+
+.history-results-header {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 11px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+
+.history-result-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 4px;
+  border-bottom: 1px solid rgba(154, 145, 138, 0.1);
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.15s;
+}
+
+.history-result-item:last-child {
+  border-bottom: none;
+}
+
+.history-result-item:hover {
+  background: rgba(90, 122, 98, 0.06);
+}
+
+.history-result-title {
+  font-size: 13px;
+  color: var(--ink);
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.history-result-host {
+  font-size: 11px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
 /* AI Debug Panel */
 .ai-debug-panel {
   position: fixed;
@@ -1656,4 +1707,41 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 .confirm-danger:hover {
   background: #9a4444;
   border-color: #9a4444;
+}
+
+/* ─── Frequent Sites (Prediction) ─────────────────────────────── */
+.frequent-section {
+  grid-column: 1 / -1;
+  margin-bottom: 24px;
+}
+.frequent-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 10px;
+}
+.freq-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  background: var(--card-bg);
+  border: 1px solid var(--warm-gray);
+  border-radius: 20px;
+  text-decoration: none;
+  color: var(--ink);
+  font-size: 13px;
+  transition: border-color .15s, box-shadow .15s;
+  cursor: pointer;
+}
+.freq-chip:hover {
+  border-color: var(--accent-amber);
+  box-shadow: 0 2px 8px var(--shadow);
+}
+.freq-favicon {
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+.freq-label {
+  white-space: nowrap;
 }

--- a/extension/style.css
+++ b/extension/style.css
@@ -1156,3 +1156,432 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   opacity: 0.6;
   flex-shrink: 0;
 }
+
+
+/* ================================================================
+   AI SUGGESTION BANNER
+   Appears above domain cards when AI suggests grouping tabs together.
+   Sage/green gradient to differentiate from the amber tab-cleanup banner.
+   ================================================================ */
+
+.ai-suggestion-banner {
+  background: linear-gradient(135deg, #f0f5f0 0%, #e8f0e8 100%);
+  border: 1px solid #c8d8c8;
+  border-radius: 12px;
+  padding: 16px 20px;
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  animation: fadeUp 0.4s ease;
+  column-span: all;
+}
+
+.ai-suggestion-banner .suggestion-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+}
+
+.ai-suggestion-banner .suggestion-content {
+  flex: 1;
+}
+
+.ai-suggestion-banner .suggestion-label {
+  font-weight: 600;
+  color: var(--ink);
+  font-size: 14px;
+}
+
+.ai-suggestion-banner .suggestion-meta {
+  color: var(--muted);
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.ai-suggestion-banner .suggestion-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.ai-suggestion-banner .suggestion-actions button {
+  border: none;
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.ai-suggestion-banner .btn-accept {
+  background: #3d6b3d;
+  color: white;
+}
+
+.ai-suggestion-banner .btn-dismiss {
+  background: var(--warm-gray);
+  color: var(--muted);
+}
+
+.ai-suggestion-banner .suggestion-actions button:hover {
+  opacity: 0.8;
+}
+
+.ai-suggestion-banner.hiding {
+  animation: fadeOut 0.3s ease forwards;
+}
+
+@keyframes fadeOut {
+  to { opacity: 0; transform: translateY(-10px); }
+}
+
+/* ================================================================
+   SETTINGS PANEL
+   ================================================================ */
+
+.settings-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 6px;
+  border-radius: 6px;
+  color: var(--ink);
+  opacity: 0.4;
+  transition: opacity 0.2s, background 0.2s;
+}
+
+.settings-btn:hover {
+  opacity: 1;
+  background: rgba(26, 22, 19, 0.04);
+}
+
+.settings-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(26, 22, 19, 0.3);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: fadeIn 0.2s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.settings-panel {
+  background: #fff;
+  border-radius: 12px;
+  padding: 32px;
+  width: 100%;
+  max-width: 400px;
+  box-shadow: 0 16px 48px rgba(26, 22, 19, 0.15);
+  animation: panelUp 0.25s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes panelUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.settings-title {
+  font-family: 'Newsreader', serif;
+  font-weight: 400;
+  font-size: 20px;
+  color: var(--ink);
+  margin-bottom: 24px;
+}
+
+.settings-panel label {
+  display: block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+  font-weight: 600;
+  color: var(--muted);
+  margin-bottom: 6px;
+  margin-top: 16px;
+}
+
+.settings-panel label:first-of-type {
+  margin-top: 0;
+}
+
+.settings-panel input {
+  width: 100%;
+  padding: 10px 14px;
+  border: 1px solid var(--warm-gray);
+  border-radius: 6px;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--card-bg);
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.settings-panel input:focus {
+  border-color: var(--accent-amber);
+}
+
+.settings-panel input::placeholder {
+  color: var(--muted);
+}
+
+.settings-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 28px;
+  justify-content: flex-end;
+}
+
+.settings-cancel {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 9px 20px;
+  border-radius: 6px;
+  border: 1px solid var(--warm-gray);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.settings-cancel:hover {
+  border-color: var(--ink);
+  color: var(--ink);
+}
+
+.settings-save {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 9px 20px;
+  border-radius: 6px;
+  border: none;
+  background: var(--ink);
+  color: var(--paper);
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.settings-save:hover {
+  opacity: 0.85;
+}
+
+/* ================================================================
+   AI CLOSE SUGGESTION BANNER
+   Appears when AI recommends closing stale/unnecessary tabs.
+   Rose/red gradient to signal cleanup action.
+   ================================================================ */
+
+.ai-close-banner {
+  background: linear-gradient(135deg, rgba(179, 90, 90, 0.04), rgba(179, 90, 90, 0.08));
+  border: 1px solid rgba(179, 90, 90, 0.15);
+  border-radius: 12px;
+  padding: 16px 20px;
+  margin-bottom: 20px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  animation: fadeUp 0.4s ease;
+  column-span: all;
+}
+
+.ai-close-banner .suggestion-content { flex: 1; }
+.ai-close-banner .suggestion-label { font-weight: 600; color: var(--ink); font-size: 14px; }
+.ai-close-banner .suggestion-meta { color: var(--muted); font-size: 12px; margin-top: 2px; }
+.ai-close-banner .suggestion-actions { display: flex; gap: 8px; flex-shrink: 0; }
+.ai-close-banner .suggestion-actions button {
+  border: none; border-radius: 6px; padding: 6px 14px;
+  font-size: 12px; font-weight: 500; cursor: pointer; transition: opacity 0.2s;
+}
+.ai-close-banner .btn-close-accept { background: var(--accent-rose); color: white; }
+.ai-close-banner .btn-dismiss { background: var(--warm-gray); color: var(--muted); }
+.ai-close-banner .suggestion-actions button:hover { opacity: 0.8; }
+.ai-close-banner.hiding { animation: fadeOut 0.3s ease forwards; }
+
+/* AI Search */
+.ai-search-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+  column-span: all;
+}
+
+.ai-search-input {
+  flex: 1;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 13px;
+  padding: 10px 14px;
+  border: 1px solid var(--warm-gray);
+  border-radius: 8px;
+  background: var(--card-bg);
+  color: var(--ink);
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.ai-search-input:focus {
+  border-color: var(--accent-sage);
+}
+
+.ai-search-input::placeholder {
+  color: var(--muted);
+}
+
+.ai-search-status {
+  font-size: 11px;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+.page-chip.tab-highlighted {
+  background: rgba(90, 122, 98, 0.08);
+  border-radius: 6px;
+  box-shadow: 0 0 0 1px var(--accent-sage);
+}
+
+.page-chip.tab-dimmed {
+  opacity: 0.3;
+  transition: opacity 0.3s;
+}
+
+/* AI Debug Panel */
+.ai-debug-panel {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  max-height: 320px;
+  overflow-y: auto;
+  background: #1a1a1a;
+  color: #e0e0e0;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 11px;
+  z-index: 9999;
+  border-top: 2px solid var(--accent-amber);
+  display: none;
+}
+
+.ai-debug-panel .debug-header {
+  position: sticky;
+  top: 0;
+  background: #222;
+  padding: 8px 16px;
+  font-weight: 600;
+  font-size: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-bottom: 1px solid #333;
+}
+
+.ai-debug-panel .debug-triggers {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+  margin-right: 12px;
+}
+
+.ai-debug-panel .debug-triggers button {
+  background: #333;
+  border: 1px solid #555;
+  color: #ccc;
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.ai-debug-panel .debug-triggers button:hover {
+  background: var(--accent-amber);
+  color: #000;
+  border-color: var(--accent-amber);
+}
+
+.ai-debug-panel .debug-close {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.ai-debug-panel .debug-close:hover { color: #fff; }
+
+.ai-debug-panel .debug-empty {
+  padding: 16px;
+  color: #666;
+  text-align: center;
+}
+
+.ai-debug-panel .debug-entry {
+  border-bottom: 1px solid #2a2a2a;
+  padding: 0;
+}
+
+.ai-debug-panel .debug-entry summary {
+  padding: 8px 16px;
+  cursor: pointer;
+  color: #aaa;
+}
+
+.ai-debug-panel .debug-entry summary:hover { background: #252525; }
+
+.ai-debug-panel .debug-entry[open] summary { color: var(--accent-amber); }
+
+.ai-debug-panel .debug-section {
+  padding: 4px 16px 8px 32px;
+}
+
+.ai-debug-panel .debug-section strong {
+  color: #8ab4f8;
+  font-size: 10px;
+  text-transform: uppercase;
+}
+
+.ai-debug-panel .debug-section pre {
+  margin: 4px 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 150px;
+  overflow-y: auto;
+  background: #111;
+  padding: 8px;
+  border-radius: 4px;
+  line-height: 1.4;
+}
+
+.settings-debug-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.settings-test-ai {
+  margin-top: 10px;
+  width: 100%;
+  padding: 8px;
+  background: #333;
+  border: 1px solid #555;
+  color: #ccc;
+  border-radius: 6px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.settings-test-ai:hover {
+  background: var(--accent-amber);
+  color: #000;
+  border-color: var(--accent-amber);
+}

--- a/extension/style.css
+++ b/extension/style.css
@@ -894,16 +894,23 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
    ================================================================ */
 
 /* ---- Two-column layout ---- */
+.top-row {
+  display: flex;
+  gap: 32px;
+  align-items: flex-start;
+  margin-bottom: 32px;
+}
+
 .dashboard-columns {
   display: flex;
   gap: 32px;
   align-items: flex-start;
 }
 
-/* Open tabs column keeps the grid layout */
+/* Open tabs column */
 .dashboard-columns .active-section {
   flex: 1;
-  min-width: 600px;
+  min-width: 0;
 }
 
 /* Saved for later column — fixed width on the right, scrolls independently */
@@ -1459,9 +1466,8 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 
 /* History search results */
 .history-results-section {
-  margin-top: 20px;
-  padding-top: 16px;
-  border-top: 1px solid rgba(154, 145, 138, 0.15);
+  flex: 1;
+  min-width: 0;
 }
 
 .history-results-header {
@@ -1711,8 +1717,8 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 
 /* ─── Frequent Sites (Prediction) ─────────────────────────────── */
 .frequent-section {
-  grid-column: 1 / -1;
-  margin-bottom: 24px;
+  flex: 1;
+  min-width: 0;
 }
 .frequent-list {
   display: flex;
@@ -1744,4 +1750,70 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
 }
 .freq-label {
   white-space: nowrap;
+}
+.freq-dismiss {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border: none;
+  background: rgba(26, 22, 19, 0.08);
+  border-radius: 50%;
+  font-size: 13px;
+  line-height: 1;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  margin-left: -2px;
+  transition: background 0.15s, color 0.15s;
+}
+.freq-chip:hover .freq-dismiss {
+  display: inline-flex;
+}
+.freq-dismiss:hover {
+  background: var(--accent-rose);
+  color: #fff;
+}
+
+/* Blacklist in settings */
+.settings-blacklist-section {
+  margin-top: 20px;
+  border-top: 1px solid var(--warm-gray);
+  padding-top: 16px;
+}
+.blacklist-list {
+  margin-top: 8px;
+  max-height: 160px;
+  overflow-y: auto;
+}
+.blacklist-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 0;
+  border-bottom: 1px solid rgba(26, 22, 19, 0.05);
+}
+.blacklist-host {
+  font-size: 13px;
+  color: var(--ink);
+}
+.blacklist-remove {
+  border: none;
+  background: none;
+  font-size: 16px;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 4px;
+  transition: background 0.15s, color 0.15s;
+}
+.blacklist-remove:hover {
+  background: rgba(26, 22, 19, 0.06);
+  color: var(--ink);
+}
+.blacklist-empty {
+  font-size: 12px;
+  color: var(--muted);
+  padding: 8px 0;
 }


### PR DESCRIPTION
Fix suspended tab URL extraction to support Tab Suspender extension.

When tabs are suspended by Tab Suspender, their URLs are wrapped in a redirect format. This PR extracts the original URL so grouping works correctly.