### PR TITLE
Feature/chrome tab groups - feat: support native Chrome Tab Groups

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Enforce LF line endings for all text files across different OS/environments
+* text=auto eol=lf
+
+# Explicitly declare web assets to use LF
+*.js text eol=lf
+*.html text eol=lf
+*.css text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.svg text eol=lf
+
+# Keep binary files as binary (no line ending normalization)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary

--- a/extension/app.js
+++ b/extension/app.js
@@ -25,11 +25,14 @@
 
 // All open tabs — populated by fetchOpenTabs()
 let openTabs = [];
+// Map of chrome native groupId -> group object (with title, color, collapsed, windowId)
+let chromeGroupsMap = new Map();
 
 /**
  * fetchOpenTabs()
  *
- * Reads all currently open browser tabs directly from Chrome.
+ * Reads all currently open browser tabs directly from Chrome,
+ * and fetches any native Chrome Tab Groups.
  * Sets the extensionId flag so we can identify Tab Out's own pages.
  */
 async function fetchOpenTabs() {
@@ -38,19 +41,31 @@ async function fetchOpenTabs() {
     // The new URL for this page is now index.html (not newtab.html)
     const newtabUrl = `chrome-extension://${extensionId}/index.html`;
 
-    const tabs = await chrome.tabs.query({});
+    // Fetch both tabs and groups if permissions/API available
+    const [tabs, groups] = await Promise.all([
+      chrome.tabs.query({}),
+      chrome.tabGroups ? chrome.tabGroups.query({}) : Promise.resolve([])
+    ]);
+
+    chromeGroupsMap.clear();
+    for (const g of groups) {
+      chromeGroupsMap.set(g.id, g);
+    }
+
     openTabs = tabs.map(t => ({
       id:       t.id,
       url:      t.url,
       title:    t.title,
       windowId: t.windowId,
       active:   t.active,
+      groupId:  t.groupId,
       // Flag Tab Out's own pages so we can detect duplicate new tabs
       isTabOut: t.url === newtabUrl || t.url === 'chrome://newtab/',
     }));
-  } catch {
-    // chrome.tabs API unavailable (shouldn't happen in an extension page)
+  } catch (err) {
+    console.error('[tab-out] Error fetching tabs/groups:', err);
     openTabs = [];
+    chromeGroupsMap.clear();
   }
 }
 
@@ -804,6 +819,7 @@ function renderDomainCard(group) {
   const tabs      = group.tabs || [];
   const tabCount  = tabs.length;
   const isLanding = group.domain === '__landing-pages__';
+  const isChromeGroup = !!group.isChromeGroup;
   const stableId  = 'domain-' + group.domain.replace(/[^a-z0-9]/g, '-');
 
   // Count duplicates (exact URL match)
@@ -817,6 +833,10 @@ function renderDomainCard(group) {
     ${ICONS.tabs}
     ${tabCount} tab${tabCount !== 1 ? 's' : ''} open
   </span>`;
+
+  const chromeGroupBadge = isChromeGroup
+    ? `<span class="open-tabs-badge" style="color:var(--text);background:rgba(255,255,255,0.08);">Chrome Group</span>`
+    : '';
 
   const dupeBadge = hasDupes
     ? `<span class="open-tabs-badge" style="color:var(--accent-amber);background:rgba(200,113,58,0.08);">
@@ -835,7 +855,9 @@ function renderDomainCard(group) {
   const extraCount  = uniqueTabs.length - visibleTabs.length;
 
   const pageChips = visibleTabs.map(tab => {
-    let label = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), group.domain);
+    let hostname = '';
+    try { hostname = new URL(tab.url).hostname; } catch {}
+    let label = cleanTitle(smartTitle(stripTitleNoise(tab.title || ''), tab.url), hostname);
     // For localhost tabs, prepend port number so you can tell projects apart
     try {
       const parsed = new URL(tab.url);
@@ -863,11 +885,26 @@ function renderDomainCard(group) {
     </div>`;
   }).join('') + (extraCount > 0 ? buildOverflowChips(uniqueTabs.slice(8), urlCounts) : '');
 
-  let actionsHtml = `
-    <button class="action-btn close-tabs" data-action="close-domain-tabs" data-domain-id="${stableId}">
-      ${ICONS.close}
-      Close all ${tabCount} tab${tabCount !== 1 ? 's' : ''}
-    </button>`;
+  let actionsHtml = '';
+  if (isChromeGroup) {
+    actionsHtml = `
+      <button class="action-btn close-tabs" data-action="close-chrome-group" data-group-id="${group.groupId}">
+        ${ICONS.close}
+        Close group
+      </button>
+      <button class="action-btn" data-action="ungroup-chrome-group" data-group-id="${group.groupId}">
+        Ungroup group
+      </button>`;
+  } else {
+    actionsHtml = `
+      <button class="action-btn close-tabs" data-action="close-domain-tabs" data-domain-id="${stableId}">
+        ${ICONS.close}
+        Close all ${tabCount} tab${tabCount !== 1 ? 's' : ''}
+      </button>
+      <button class="action-btn" data-action="group-domain-tabs" data-domain-id="${stableId}">
+        Group tabs
+      </button>`;
+  }
 
   if (hasDupes) {
     const dupeUrlsEncoded = dupeUrls.map(([url]) => encodeURIComponent(url)).join(',');
@@ -877,12 +914,26 @@ function renderDomainCard(group) {
       </button>`;
   }
 
+  let groupTitle = '';
+  if (isChromeGroup) {
+    groupTitle = group.label || `Group ${group.groupId}`;
+  } else if (isLanding) {
+    groupTitle = 'Homepages';
+  } else {
+    groupTitle = group.label || friendlyDomain(group.domain);
+  }
+
+  const statusClass = isChromeGroup
+    ? `group-color-${group.groupColor || 'grey'}`
+    : (hasDupes ? 'has-amber-bar' : 'has-neutral-bar');
+
   return `
-    <div class="mission-card domain-card ${hasDupes ? 'has-amber-bar' : 'has-neutral-bar'}" data-domain-id="${stableId}">
+    <div class="mission-card domain-card ${statusClass}" data-domain-id="${stableId}">
       <div class="status-bar"></div>
       <div class="mission-content">
         <div class="mission-top">
-          <span class="mission-name">${isLanding ? 'Homepages' : (group.label || friendlyDomain(group.domain))}</span>
+          <span class="mission-name">${groupTitle}</span>
+          ${chromeGroupBadge}
           ${tabBadge}
           ${dupeBadge}
         </div>
@@ -1089,6 +1140,26 @@ async function renderStaticDashboard() {
 
   for (const tab of realTabs) {
     try {
+      // First, check if the tab belongs to a native Chrome Tab Group
+      if (tab.groupId !== undefined && tab.groupId !== -1) {
+        const key = `chrome-group-${tab.groupId}`;
+        if (!groupMap[key]) {
+          const chromeGroup = chromeGroupsMap.get(tab.groupId);
+          groupMap[key] = {
+            domain: key,
+            label: chromeGroup ? (chromeGroup.title || `Group ${tab.groupId}`) : `Group ${tab.groupId}`,
+            tabs: [],
+            isChromeGroup: true,
+            groupColor: chromeGroup ? chromeGroup.color : 'grey',
+            collapsed: chromeGroup ? chromeGroup.collapsed : false,
+            groupId: tab.groupId,
+            windowId: tab.windowId
+          };
+        }
+        groupMap[key].tabs.push(tab);
+        continue;
+      }
+
       if (isLandingPage(tab.url)) {
         landingTabs.push(tab);
         continue;
@@ -1122,7 +1193,7 @@ async function renderStaticDashboard() {
     groupMap['__landing-pages__'] = { domain: '__landing-pages__', tabs: landingTabs };
   }
 
-  // Sort: landing pages first, then domains from landing page sites, then by tab count
+  // Sort: Chrome groups first, then landing pages, then domains by tab count
   // Collect exact hostnames and suffix patterns for priority sorting
   const landingHostnames = new Set(LANDING_PAGE_PATTERNS.map(p => p.hostname).filter(Boolean));
   const landingSuffixes = LANDING_PAGE_PATTERNS.map(p => p.hostnameEndsWith).filter(Boolean);
@@ -1131,6 +1202,10 @@ async function renderStaticDashboard() {
     return landingSuffixes.some(s => domain.endsWith(s));
   }
   domainGroups = Object.values(groupMap).sort((a, b) => {
+    const aIsChrome = a.isChromeGroup;
+    const bIsChrome = b.isChromeGroup;
+    if (aIsChrome !== bIsChrome) return aIsChrome ? -1 : 1;
+
     const aIsLanding = a.domain === '__landing-pages__';
     const bIsLanding = b.domain === '__landing-pages__';
     if (aIsLanding !== bIsLanding) return aIsLanding ? -1 : 1;
@@ -1336,6 +1411,98 @@ document.addEventListener('click', async (e) => {
         item.remove();
         renderDeferredColumn();
       }, 300);
+    }
+    return;
+  }
+
+  // ---- Close all tabs in a Chrome native group ----
+  if (action === 'close-chrome-group') {
+    const groupId = parseInt(actionEl.dataset.groupId, 10);
+    if (isNaN(groupId)) return;
+
+    const group = domainGroups.find(g => g.isChromeGroup && g.groupId === groupId);
+    if (!group) return;
+
+    const tabIds = group.tabs.map(t => t.id);
+    if (tabIds.length > 0) {
+      await chrome.tabs.remove(tabIds);
+    }
+    await fetchOpenTabs();
+
+    if (card) {
+      playCloseSound();
+      animateCardOut(card);
+    }
+
+    // Remove from in-memory groups
+    const idx = domainGroups.indexOf(group);
+    if (idx !== -1) domainGroups.splice(idx, 1);
+
+    showToast('Closed Chrome Group');
+    const statTabs = document.getElementById('statTabs');
+    if (statTabs) statTabs.textContent = openTabs.length;
+    return;
+  }
+
+  // ---- Ungroup all tabs in a Chrome native group ----
+  if (action === 'ungroup-chrome-group') {
+    const groupId = parseInt(actionEl.dataset.groupId, 10);
+    if (isNaN(groupId)) return;
+
+    const group = domainGroups.find(g => g.isChromeGroup && g.groupId === groupId);
+    if (!group) return;
+
+    const tabIds = group.tabs.map(t => t.id);
+    if (tabIds.length > 0) {
+      await chrome.tabs.ungroup(tabIds);
+    }
+    await fetchOpenTabs();
+
+    if (card) {
+      playCloseSound();
+      animateCardOut(card);
+      setTimeout(() => renderDashboard(), 300);
+    } else {
+      await renderDashboard();
+    }
+
+    showToast('Ungrouped Chrome Group');
+    return;
+  }
+
+  // ---- Convert a domain group card to a Chrome native group ----
+  if (action === 'group-domain-tabs') {
+    const domainId = actionEl.dataset.domainId;
+    const group = domainGroups.find(g => {
+      return 'domain-' + g.domain.replace(/[^a-z0-9]/g, '-') === domainId;
+    });
+    if (!group) return;
+
+    const tabIds = group.tabs.map(t => t.id);
+    if (tabIds.length === 0) return;
+
+    try {
+      const newGroupId = await chrome.tabs.group({ tabIds });
+      const title = group.label || friendlyDomain(group.domain);
+      const colors = ['blue', 'green', 'red', 'yellow', 'pink', 'purple', 'cyan', 'orange'];
+      const randomColor = colors[Math.floor(Math.random() * colors.length)];
+      
+      await chrome.tabGroups.update(newGroupId, { title, color: randomColor });
+      
+      await fetchOpenTabs();
+      
+      if (card) {
+        playCloseSound();
+        animateCardOut(card);
+        setTimeout(() => renderDashboard(), 300);
+      } else {
+        await renderDashboard();
+      }
+      
+      showToast(`Grouped tabs into Chrome Group: ${title}`);
+    } catch (err) {
+      console.error('[tab-out] Failed to group tabs:', err);
+      showToast('Failed to create Chrome Group');
     }
     return;
   }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tab Out",
   "version": "1.0.0",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
-  "permissions": ["tabs", "activeTab", "storage"],
+  "permissions": ["tabs", "activeTab", "storage", "tabGroups"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },
   "action": {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tab Out",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
   "permissions": ["tabs", "activeTab", "storage", "tabGroups"],
   "chrome_url_overrides": { "newtab": "index.html" },

--- a/extension/style.css
+++ b/extension/style.css
@@ -254,6 +254,17 @@ header {
 .mission-card.has-amber-bar::before { background: var(--accent-amber); }
 .mission-card.has-neutral-bar::before { background: var(--warm-gray); }
 
+/* Chrome Tab Group Colors */
+.mission-card.group-color-grey::before   { background: var(--accent-slate); }
+.mission-card.group-color-blue::before   { background: #5a8ab5; }
+.mission-card.group-color-red::before    { background: var(--accent-rose); }
+.mission-card.group-color-yellow::before { background: var(--status-cooling); }
+.mission-card.group-color-green::before  { background: var(--accent-sage); }
+.mission-card.group-color-pink::before   { background: #c0809b; }
+.mission-card.group-color-purple::before { background: #8b80b0; }
+.mission-card.group-color-cyan::before   { background: #5a8e8f; }
+.mission-card.group-color-orange::before { background: var(--accent-amber); }
+
 .mission-card:hover {
   box-shadow: 0 4px 20px var(--shadow);
   transform: translateY(-1px);

--- a/md/plan.md
+++ b/md/plan.md
@@ -1,0 +1,127 @@
+# Implementation Plan: Chrome Tab Group Integration for Tab Out
+
+This document outlines the proposed design and implementation steps for integrating Chrome's native **Tab Groups** feature into the **Tab Out** extension.
+
+---
+
+## 1. Feasibility & Value Analysis
+
+### Is this a good idea?
+**Yes, this is an excellent idea.**
+Currently, Tab Out groups tabs solely by domain on its custom dashboard. While this is helpful for cleanups, it completely ignores the user's manual organization. 
+Integrating Chrome's native Tab Groups creates a unified experience:
+1. **Respects User Organization**: If a user has already grouped tabs (e.g., "Work", "Research", "Leisure") in their browser, the dashboard will display these distinct contexts as their own cards rather than mixing them by domain.
+2. **Unified Dashboard**: Tab Out becomes a powerful controller for native Tab Groups—allowing users to close, rename, or color-code groups from the dashboard.
+3. **Automated Grouping**: Users can group a chaotic pile of domain-matched tabs into a native Chrome Tab Group with a single click.
+
+---
+
+## 2. Technical Overview & API Access
+
+To interact with Chrome's native Tab Groups, we must utilize the `chrome.tabGroups` and `chrome.tabs` APIs.
+
+### A. Permission Changes (`manifest.json`)
+We need to add the `"tabGroups"` permission to allow querying and modifying group titles, colors, and collapsed states.
+```json
+"permissions": ["tabs", "activeTab", "storage", "tabGroups"]
+```
+> [!NOTE]
+> Adding a new permission to an existing published extension triggers a browser warning requiring user re-approval. For a personal fork, this is not an issue.
+
+### B. Core API Methods Needed
+* **Query groups**: `chrome.tabGroups.query(object queryInfo)` gets all active groups.
+* **Get group details**: `chrome.tabGroups.get(int groupId)` gets metadata for a specific group (title, color, collapsed state).
+* **Create/Add tabs to group**: `chrome.tabs.group({ tabIds: [...], groupId: existingGroupId })` groups tabs.
+* **Ungroup tabs**: `chrome.tabs.ungroup(int[] tabIds)` removes tabs from groups.
+* **Modify group details**: `chrome.tabGroups.update(int groupId, { title, color, collapsed })` edits group properties.
+
+---
+
+## 3. Proposed UI/UX Architecture
+
+Instead of having only domain-based cards, the dashboard will now support **two types of cards**:
+
+```
++---------------------------------------+   +---------------------------------------+
+|  [Chrome Group] Work (Blue)     [3]  |   |  github.com (Domain fallback)   [5]   |
++---------------------------------------+   +---------------------------------------+
+|  - Status bar matches group color     |   |  - Neutral status bar                 |
+|  - Displays tabs in this native group |   |  - Displays ungrouped github tabs    |
+|  - Actions:                           |   |  - Actions:                           |
+|    [Close Group] [Ungroup]            |   |    [Close tabs] [Create Chrome Group] |
++---------------------------------------+   +---------------------------------------+
+```
+
+### Color Mapping
+Chrome's native tab group colors (`grey`, `blue`, `red`, `yellow`, `green`, `pink`, `purple`, `cyan`, `orange`) can be mapped directly to Tab Out's existing CSS styling system:
+```css
+/* Color mappings for native Chrome groups */
+.group-color-grey   { --group-accent: #5a6b7a; }
+.group-color-blue   { --group-accent: #3b82f6; }
+.group-color-red    { --group-accent: #ef4444; }
+.group-color-yellow { --group-accent: #f59e0b; }
+.group-color-green  { --group-accent: #10b981; }
+.group-color-pink   { --group-accent: #ec4899; }
+.group-color-purple { --group-accent: #8b5cf6; }
+.group-color-cyan   { --group-accent: #06b6d4; }
+.group-color-orange { --group-accent: #f97316; }
+```
+
+---
+
+## 4. Implementation Steps
+
+```mermaid
+graph TD
+    Phase1[Phase 1: Update Manifest & Fetch State] --> Phase2[Phase 2: Grouping Logic Refactor]
+    Phase2 --> Phase3[Phase 3: Render Custom Group Cards]
+    Phase3 --> Phase4[Phase 4: Implement Actions - Create/Ungroup/Close]
+    Phase4 --> Phase5[Phase 5: Styling & Polish]
+```
+
+### Phase 1: Update Manifest & Fetch State
+1. Update `manifest.json` to include `"tabGroups"` in the `permissions` array.
+2. In `app.js`, modify `fetchOpenTabs()` to query both tabs and active groups:
+   ```javascript
+   const [tabs, groups] = await Promise.all([
+     chrome.tabs.query({}),
+     chrome.tabGroups.query({})
+   ]);
+   ```
+3. Map tabs to capture their `groupId`. Store the groups array in a global variable or map for quick lookup.
+
+### Phase 2: Refactor Grouping Logic
+In `renderStaticDashboard()`, adapt the grouping logic:
+1. First, partition tabs into two buckets:
+   * **Grouped tabs**: `tab.groupId !== -1` (or `chrome.tabGroups.TAB_GROUP_ID_NONE`)
+   * **Ungrouped tabs**: `tab.groupId === -1`
+2. Group the **grouped tabs** by their `groupId`. For each native group, lookup its title and color from the `groups` list.
+3. Group the **ungrouped tabs** using the existing domain-based logic (including landing pages and custom groups).
+
+### Phase 3: Render Native Group Cards
+1. Modify `renderDomainCard()` (or create a new `renderTabGroupCard()`) to support native groups:
+   * Display the native group title (or fallback to `"Group " + groupId` if untitled).
+   * Apply a CSS class matching the group's color (e.g., `group-color-blue`) to style the card header or borders dynamically.
+   * Add a badge indicating it is a "Chrome Tab Group".
+
+### Phase 4: Implement Actions
+1. **Close Native Group**: Clicking "Close Group" calls `chrome.tabs.remove(tabIds)` for all tabs in that group.
+2. **Ungroup**: Add an action button on native group cards to ungroup all tabs: `chrome.tabs.ungroup(tabIds)`.
+3. **Create Native Group from Domain Card**:
+   * For domain cards (ungrouped tabs), add a button: **"Turn into Group"**.
+   * When clicked, call `chrome.tabs.group({ tabIds })` to group them in Chrome, then update the group's title to the friendly domain name using `chrome.tabGroups.update()`.
+
+### Phase 5: Styling & Polish
+1. Add smooth CSS transitions when ungrouped domain cards transition into native group cards.
+2. Update the background badge updater in `background.js` if necessary (badge should still count all real web tabs, but we can verify it doesn't break).
+
+---
+
+## 5. Potential Challenges & Mitigations
+
+1. **Multi-Window Groups**:
+   * *Problem*: Native Tab Groups in Chrome cannot span across multiple windows.
+   * *Mitigation*: If a user has a "Work" group in Window 1 and another "Work" group in Window 2, Chrome assigns them different `groupId`s. We should display them as two separate cards (e.g., `Work (Window 1)` and `Work (Window 2)`) to reflect Chrome's actual state.
+2. **Tab Group Management Permissions**:
+   * *Problem*: System-level pages (`chrome://*`) cannot be added to tab groups.
+   * *Mitigation*: Tab Out already filters out browser internal pages in `getRealTabs()`, so this is automatically avoided.


### PR DESCRIPTION
    This PR integrates Chrome's native **Tab Groups** feature into the Tab Out dashboard.

    **Changes:**
    * **Native Groups:** Visualized as cards at the top of the dashboard, styled with their respective Chrome group colors.
    * **New Actions:** Added options to **Close Group** and **Ungroup** (dissolve group natively).
    * **Automatic Grouping:** Added a **Group tabs** button on domain cards to quickly bundle them into a native Chrome group.
    * **Version Bump:** Bumped version to `1.1.0`.
    * **Line Endings:** Added `.gitattributes` to enforce LF endings and keep diffs clean.