### PR TITLE
Favorites bookmarks section + right rail layout (CSP-safe)

### DIFF
--- a/extension/app.js
+++ b/extension/app.js
@@ -700,6 +700,7 @@ const ICONS = {
   close:   `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>`,
   archive: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5m6 4.125l2.25 2.25m0 0l2.25 2.25M12 13.875l2.25-2.25M12 13.875l-2.25 2.25M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125Z" /></svg>`,
   focus:   `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 19.5 15-15m0 0H8.25m11.25 0v11.25" /></svg>`,
+  bookmark: `<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>`,
 };
 
 
@@ -1005,6 +1006,117 @@ function renderArchiveItem(item) {
 
 
 /* ----------------------------------------------------------------
+   FAVORITES — Chrome bookmarks (chrome.bookmarks API)
+
+   Reads the user's bookmark tree and renders it as folder cards at
+   the top of the dashboard. Requires the "bookmarks" permission in
+   manifest.json. Read-only — Tab Out never modifies your bookmarks.
+   ---------------------------------------------------------------- */
+
+/**
+ * collectBookmarkFolders(node, path, out)
+ *
+ * Recursively walks a bookmark folder node. Every folder that directly
+ * contains bookmarks becomes one entry in `out`, labeled by its folder
+ * path (e.g. "Bookmarks Bar / News"). Nested folders recurse.
+ */
+function collectBookmarkFolders(node, path, out) {
+  const children = node.children || [];
+  const directLinks = children
+    .filter(c => c.url)
+    .map(c => ({ title: c.title, url: c.url }));
+
+  if (directLinks.length > 0) {
+    out.push({ title: path || node.title || 'Bookmarks', bookmarks: directLinks });
+  }
+
+  for (const child of children) {
+    if (!child.url && child.children) {
+      const childPath = path ? `${path} / ${child.title}` : child.title;
+      collectBookmarkFolders(child, childPath, out);
+    }
+  }
+}
+
+/**
+ * renderBookmarkCard(folder)
+ *
+ * Builds one folder card. Each bookmark is a favicon + title link that
+ * opens the site in the current tab (target="_top").
+ */
+function renderBookmarkCard(folder) {
+  const chips = folder.bookmarks.map(bm => {
+    const safeUrl = (bm.url || '').replace(/"/g, '&quot;');
+    const label   = (bm.title || bm.url || '').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const safeTitle = label.replace(/"/g, '&quot;');
+    let domain = '';
+    try { domain = new URL(bm.url).hostname; } catch {}
+    const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
+    return `<a class="page-chip bookmark-chip clickable" href="${safeUrl}" target="_top" title="${safeTitle}">
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
+      <span class="chip-text">${label || bm.url}</span>
+    </a>`;
+  }).join('');
+
+  const count = folder.bookmarks.length;
+  const safeFolder = (folder.title || 'Bookmarks').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+  return `
+    <div class="mission-card bookmark-card has-neutral-bar">
+      <div class="status-bar"></div>
+      <div class="mission-content">
+        <div class="mission-top">
+          <span class="mission-name">${safeFolder}</span>
+          <span class="open-tabs-badge">${ICONS.bookmark} ${count} bookmark${count !== 1 ? 's' : ''}</span>
+        </div>
+        <div class="mission-pages">${chips}</div>
+      </div>
+    </div>`;
+}
+
+/**
+ * renderBookmarksSection()
+ *
+ * Loads Chrome bookmarks and paints the Favorites section. Hides the
+ * section if there are no bookmarks or the API isn't available.
+ */
+async function renderBookmarksSection() {
+  const section = document.getElementById('bookmarksSection');
+  const grid    = document.getElementById('bookmarksGrid');
+  const countEl = document.getElementById('bookmarksSectionCount');
+  if (!section || !grid) return;
+
+  // chrome.bookmarks is only present if the "bookmarks" permission is granted
+  if (!chrome.bookmarks || !chrome.bookmarks.getTree) {
+    section.style.display = 'none';
+    return;
+  }
+
+  try {
+    const tree = await chrome.bookmarks.getTree();
+    const root = tree[0];
+    const folders = [];
+    for (const top of (root.children || [])) {
+      collectBookmarkFolders(top, top.title, folders);
+    }
+
+    const total = folders.reduce((sum, f) => sum + f.bookmarks.length, 0);
+    if (total === 0) {
+      section.style.display = 'none';
+      return;
+    }
+
+    if (countEl) countEl.textContent = `${total} bookmark${total !== 1 ? 's' : ''}`;
+    grid.innerHTML = folders.map(renderBookmarkCard).join('');
+    section.style.display = 'block';
+  } catch (err) {
+    console.warn('[tab-out] Could not load bookmarks:', err);
+    section.style.display = 'none';
+  }
+}
+
+
+/* ----------------------------------------------------------------
    MAIN DASHBOARD RENDERER
    ---------------------------------------------------------------- */
 
@@ -1163,6 +1275,9 @@ async function renderStaticDashboard() {
 
   // --- Check for duplicate Tab Out tabs ---
   checkTabOutDupes();
+
+  // --- Render Favorites (Chrome bookmarks) ---
+  await renderBookmarksSection();
 
   // --- Render "Saved for Later" column ---
   await renderDeferredColumn();

--- a/extension/app.js
+++ b/extension/app.js
@@ -770,8 +770,8 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
     try { domain = new URL(tab.url).hostname; } catch {}
     const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="">` : ''}
+      <span class="chip-text">${escapeHtml(label)}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
@@ -794,6 +794,23 @@ function buildOverflowChips(hiddenTabs, urlCounts = {}) {
 /* ----------------------------------------------------------------
    DOMAIN CARD RENDERER
    ---------------------------------------------------------------- */
+
+/**
+ * escapeHtml(str)
+ *
+ * Escapes text before it goes into an innerHTML template. Tab/bookmark
+ * titles are arbitrary strings — a title like `foo <img src=x onerror=…>`
+ * would otherwise inject markup, which both breaks the extension CSP
+ * (inline event handlers are forbidden) and is an XSS vector.
+ */
+function escapeHtml(str) {
+  return String(str ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
 
 /**
  * renderDomainCard(group, groupIndex)
@@ -851,8 +868,8 @@ function renderDomainCard(group) {
     try { domain = new URL(tab.url).hostname; } catch {}
     const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
     return `<div class="page-chip clickable${chipClass}" data-action="focus-tab" data-tab-url="${safeUrl}" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label}</span>${dupeTag}
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="">` : ''}
+      <span class="chip-text">${escapeHtml(label)}</span>${dupeTag}
       <div class="chip-actions">
         <button class="chip-action chip-save" data-action="defer-single-tab" data-tab-url="${safeUrl}" data-tab-title="${safeTitle}" title="Save for later">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" /></svg>
@@ -883,7 +900,7 @@ function renderDomainCard(group) {
       <div class="status-bar"></div>
       <div class="mission-content">
         <div class="mission-top">
-          <span class="mission-name">${isLanding ? 'Homepages' : (group.label || friendlyDomain(group.domain))}</span>
+          <span class="mission-name">${isLanding ? 'Homepages' : escapeHtml(group.label || friendlyDomain(group.domain))}</span>
           ${tabBadge}
           ${dupeBadge}
         </div>
@@ -975,7 +992,7 @@ function renderDeferredItem(item) {
       <input type="checkbox" class="deferred-checkbox" data-action="check-deferred" data-deferred-id="${item.id}">
       <div class="deferred-info">
         <a href="${item.url}" target="_blank" rel="noopener" class="deferred-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
-          <img src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px" onerror="this.style.display='none'">${item.title || item.url}
+          <img class="chip-favicon" src="${faviconUrl}" alt="" style="width:14px;height:14px;vertical-align:-2px;margin-right:4px">${escapeHtml(item.title || item.url)}
         </a>
         <div class="deferred-meta">
           <span>${domain}</span>
@@ -998,7 +1015,7 @@ function renderArchiveItem(item) {
   return `
     <div class="archive-item">
       <a href="${item.url}" target="_blank" rel="noopener" class="archive-item-title" title="${(item.title || '').replace(/"/g, '&quot;')}">
-        ${item.title || item.url}
+        ${escapeHtml(item.title || item.url)}
       </a>
       <span class="archive-item-date">${ago}</span>
     </div>`;
@@ -1046,20 +1063,19 @@ function collectBookmarkFolders(node, path, out) {
  */
 function renderBookmarkCard(folder) {
   const chips = folder.bookmarks.map(bm => {
-    const safeUrl = (bm.url || '').replace(/"/g, '&quot;');
-    const label   = (bm.title || bm.url || '').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    const safeTitle = label.replace(/"/g, '&quot;');
+    const safeUrl = escapeHtml(bm.url || '');
+    const label   = escapeHtml(bm.title || bm.url || '');
     let domain = '';
     try { domain = new URL(bm.url).hostname; } catch {}
     const faviconUrl = domain ? `https://www.google.com/s2/favicons?domain=${domain}&sz=16` : '';
-    return `<a class="page-chip bookmark-chip clickable" href="${safeUrl}" target="_top" title="${safeTitle}">
-      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="" onerror="this.style.display='none'">` : ''}
-      <span class="chip-text">${label || bm.url}</span>
+    return `<a class="page-chip bookmark-chip clickable" href="${safeUrl}" target="_top" title="${label}">
+      ${faviconUrl ? `<img class="chip-favicon" src="${faviconUrl}" alt="">` : ''}
+      <span class="chip-text">${label}</span>
     </a>`;
   }).join('');
 
   const count = folder.bookmarks.length;
-  const safeFolder = (folder.title || 'Bookmarks').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const safeFolder = escapeHtml(folder.title || 'Bookmarks');
 
   return `
     <div class="mission-card bookmark-card has-neutral-bar">
@@ -1295,6 +1311,16 @@ async function renderDashboard() {
    Think of it as one security guard watching the whole building
    instead of one per door.
    ---------------------------------------------------------------- */
+
+// Favicons that 404 should quietly disappear. Inline onerror="" handlers
+// violate the extension CSP (no inline script), so we delegate instead.
+// Image error events don't bubble, hence the capture phase.
+document.addEventListener('error', (e) => {
+  const img = e.target;
+  if (img instanceof HTMLImageElement && img.classList.contains('chip-favicon')) {
+    img.style.display = 'none';
+  }
+}, true);
 
 document.addEventListener('click', async (e) => {
   // Walk up the DOM to find the nearest element with data-action

--- a/extension/index.html
+++ b/extension/index.html
@@ -144,7 +144,7 @@
 
 <!-- Personal config (gitignored) — defines LOCAL_LANDING_PAGE_PATTERNS etc. -->
 <!-- If the file doesn't exist, that's fine — app.js uses sensible defaults. -->
-<script src="config.local.js" onerror="/* no personal config, that's fine */"></script>
+<script src="config.local.js"></script>
 
 <!-- Main dashboard logic — loads last so the DOM is ready -->
 <script src="app.js"></script>

--- a/extension/index.html
+++ b/extension/index.html
@@ -49,8 +49,8 @@
   <!-- ================================================================
        MAIN CONTENT AREA — two-column layout
        Left: open tabs (domain/mission cards)
-       Right: saved for later checklist
-       The right column only renders when it has items (JS controls this)
+       Right rail: Favorites (bookmarks) + Saved for later checklist
+       Both right-rail sections only render when they have items (JS controls this)
        ================================================================ -->
   <div class="dashboard-columns" id="dashboardColumns">
 
@@ -64,7 +64,22 @@
       <div class="missions" id="openTabsMissions"></div>
     </div>
 
-    <!-- RIGHT COLUMN: Saved for Later checklist -->
+    <!-- RIGHT RAIL: Favorites (bookmarks) stacked above Saved for later -->
+    <div class="right-rail" id="rightRail">
+
+    <!-- FAVORITES — your Chrome bookmarks, grouped by folder
+         Hidden by default; app.js shows it via renderBookmarksSection()
+         when bookmarks exist (needs the "bookmarks" permission). -->
+    <div class="bookmarks-section" id="bookmarksSection" style="display:none">
+      <div class="section-header">
+        <h2>Favorites</h2>
+        <div class="section-line"></div>
+        <div class="section-count" id="bookmarksSectionCount"></div>
+      </div>
+      <div class="missions" id="bookmarksGrid"></div>
+    </div>
+
+    <!-- Saved for Later checklist -->
     <div class="deferred-column" id="deferredColumn" style="display:none">
       <div class="section-header">
         <h2>Saved for later</h2>
@@ -93,6 +108,8 @@
         </div>
       </div>
     </div>
+
+    </div><!-- end .right-rail -->
 
   </div><!-- end .dashboard-columns -->
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tab Out",
   "version": "1.0.0",
   "description": "Keep tabs on your tabs. New tab page that groups your open tabs by domain and lets you close them with style.",
-  "permissions": ["tabs", "activeTab", "storage"],
+  "permissions": ["tabs", "activeTab", "storage", "bookmarks"],
   "chrome_url_overrides": { "newtab": "index.html" },
   "background": { "service_worker": "background.js" },
   "action": {

--- a/extension/style.css
+++ b/extension/style.css
@@ -467,6 +467,21 @@ header {
   padding: 6px 4px;
 }
 
+/* ---- Bookmark links (Favorites section) ---- */
+/* Reuses .page-chip layout, but each chip is an <a>, so reset link styles */
+.bookmark-chip {
+  text-decoration: none;
+  color: var(--ink);
+}
+
+.bookmark-chip:hover {
+  background: rgba(90, 122, 98, 0.06);
+}
+
+.bookmark-chip .chip-text {
+  -webkit-line-clamp: 1;  /* bookmarks are single-line for a tidier list */
+}
+
 /* mission-meta hidden — see above */
 
 .mission-time {
@@ -901,14 +916,40 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   min-width: 600px;
 }
 
-/* Saved for later column — fixed width on the right, scrolls independently */
-.deferred-column {
-  width: 280px;
+/* Right rail — fixed width on the right, scrolls independently.
+   Holds Favorites (bookmarks) stacked above Saved for later. */
+.right-rail {
+  width: 300px;
   flex-shrink: 0;
   position: sticky;
   top: 32px;
   max-height: calc(100vh - 64px);
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+/* Collapse the rail (no reserved 300px gap) when neither Favorites nor
+   Saved for later is visible. app.js toggles each section's inline
+   display between none/block, so a visible child has display:block. */
+.right-rail:not(:has(> [style*="block"])) {
+  display: none;
+}
+
+/* Inside the rail, sections fill the rail's width; the rail owns the
+   sticky/scroll behavior, so reset the nested column's own sizing. */
+.right-rail .deferred-column {
+  width: 100%;
+  position: static;
+  max-height: none;
+  overflow: visible;
+}
+
+/* Favorites cards stack in a single column inside the narrow rail */
+.right-rail .bookmarks-section .missions {
+  columns: auto;
+  margin-bottom: 0;
 }
 
 /* On narrow screens, stack vertically */
@@ -916,9 +957,11 @@ footer { animation: fadeUp 0.5s ease 0.65s both; }
   .dashboard-columns {
     flex-direction: column;
   }
-  .deferred-column {
+  .right-rail {
     width: 100%;
     position: static;
+    max-height: none;
+    overflow: visible;
   }
 }
 


### PR DESCRIPTION
## What

Two related changes:

### 1. Favorites bookmarks section + right-rail layout
- Surfaces Chrome bookmarks as folder cards via a new **read-only** `bookmarks` permission.
- Reworks the dashboard into open tabs on the left with a right rail holding **Favorites** above **Saved for later**. The rail collapses when both sections are empty.

### 2. Content Security Policy fixes
The extension new-tab page runs under `script-src 'self'`, which forbids inline JavaScript. Two sources were violating it (the second only surfaced once the Favorites section started rendering more favicons/titles):

- **Inline event handlers** — `onerror=""` on favicon `<img>` tags and a dead `onerror` on the `config.local.js` `<script>`. Favicon load failures are now handled by a single capture-phase `error` listener (image `error` events don't bubble, hence capture phase).
- **Unescaped titles** — tab/bookmark titles were interpolated raw into `innerHTML`. A title containing markup (e.g. `<img src=x onerror=...>`) injected a live inline handler — a CSP violation **and** an XSS vector. Added a shared `escapeHtml()` helper applied at every text-into-`innerHTML` site: chip labels, custom group names, saved/archived titles, and bookmark cards (replacing inconsistent ad-hoc escaping).

## Why
Without the escaping/handler fixes, the Favorites section trips the extension CSP and blocks rendering actions in the console.

## Notes for reviewer
- The `bookmarks` permission is used read-only — Tab Out never modifies bookmarks.
- `manifest.json` version is unchanged (`1.0.0`).
- Verified working locally (extension reloaded, CSP violations gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
